### PR TITLE
Convert to Typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules
 _site
 /HyperTalk Reference 2.4.pdf
+.DS_Store

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "typescript",
+			"tsconfig": "tsconfig.json",
+			"problemMatcher": [
+				"$tsc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"label": "tsc: build - tsconfig.json"
+		}
+	]
+}

--- a/dist/_hyperscript.js
+++ b/dist/_hyperscript.js
@@ -102,7 +102,7 @@
                         return token;
                     }
                     else {
-                        raiseError(this, "Expected one of " + JSON.stringify([type1, type2, type3]));
+                        raiseError(this, "Expected one of " + JSON.stringify([type1, type2, type3, type4]));
                     }
                 }
                 function matchTokenType(type1, type2, type3, type4) {
@@ -137,7 +137,10 @@
                     var tokenList = [];
                     ignoreWhiteSpace = false;
                     while (currentToken() && currentToken().type !== "WHITESPACE") {
-                        tokenList.push(consumeToken());
+                        var nextToken = consumeToken();
+                        if (nextToken != undefined) {
+                            tokenList.push(nextToken);
+                        }
                     }
                     ignoreWhiteSpace = true;
                     return tokenList;
@@ -440,11 +443,12 @@
                 }
             }
             function evalTarget(root, path) {
+                var last;
                 if (root.length) {
-                    var last = root;
+                    last = root;
                 }
                 else {
-                    var last = [root];
+                    last = [root];
                 }
                 while (path.length > 0) {
                     var prop = path.shift();
@@ -490,20 +494,23 @@
                 return Object.prototype.toString.call(o) === "[object " + type + "]";
             }
             function evaluate(typeOrSrc, srcOrCtx, ctxArg) {
+                var src;
+                var type;
+                var ctx;
                 if (isType(srcOrCtx, "Object")) {
-                    var src = typeOrSrc;
-                    var ctx = srcOrCtx;
-                    var type = "expression";
+                    src = typeOrSrc;
+                    ctx = srcOrCtx;
+                    type = "expression";
                 }
                 else if (isType(srcOrCtx, "String")) {
-                    var src = srcOrCtx;
-                    var type = typeOrSrc;
-                    var ctx = ctxArg;
+                    src = srcOrCtx;
+                    type = typeOrSrc;
+                    ctx = ctxArg;
                 }
                 else {
-                    var src = typeOrSrc;
-                    var ctx = {};
-                    var type = "expression";
+                    src = typeOrSrc;
+                    ctx = {};
+                    type = "expression";
                 }
                 ctx = ctx || {};
                 var compiled = _parser.parseElement(type, _lexer.tokenize(src)).transpile();

--- a/dist/_hyperscript.js
+++ b/dist/_hyperscript.js
@@ -3,1679 +3,1564 @@
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define([], factory);
-    } else {
+    }
+    else {
         // Browser globals
         root._hyperscript = factory();
     }
 }(typeof self !== 'undefined' ? self : this, function () {
     return (function () {
-            'use strict';
-
-            //-----------------------------------------------
-            // Lexer
-            //-----------------------------------------------
-            var _lexer = function () {
-                var OP_TABLE = {
-                    '+': 'PLUS',
-                    '-': 'MINUS',
-                    '*': 'MULTIPLY',
-                    '/': 'DIVIDE',
-                    '.': 'PERIOD',
-                    '\\': 'BACKSLASH',
-                    ':': 'COLON',
-                    '%': 'PERCENT',
-                    '|': 'PIPE',
-                    '!': 'EXCLAMATION',
-                    '?': 'QUESTION',
-                    '#': 'POUND',
-                    '&': 'AMPERSAND',
-                    ';': 'SEMI',
-                    ',': 'COMMA',
-                    '(': 'L_PAREN',
-                    ')': 'R_PAREN',
-                    '<': 'L_ANG',
-                    '>': 'R_ANG',
-                    '<=': 'LTE_ANG',
-                    '>=': 'GTE_ANG',
-                    '==': 'EQ',
-                    '===': 'EQQ',
-                    '{': 'L_BRACE',
-                    '}': 'R_BRACE',
-                    '[': 'L_BRACKET',
-                    ']': 'R_BRACKET',
-                    '=': 'EQUALS'
-                };
-
-                function isValidCSSClassChar(c) {
-                    return isAlpha(c) || isNumeric(c) || c === "-" || c === "_";
+        'use strict';
+        //-----------------------------------------------
+        // Lexer
+        //-----------------------------------------------            
+        var _lexer = function () {
+            var OP_TABLE = {
+                '+': 'PLUS',
+                '-': 'MINUS',
+                '*': 'MULTIPLY',
+                '/': 'DIVIDE',
+                '.': 'PERIOD',
+                '\\': 'BACKSLASH',
+                ':': 'COLON',
+                '%': 'PERCENT',
+                '|': 'PIPE',
+                '!': 'EXCLAMATION',
+                '?': 'QUESTION',
+                '#': 'POUND',
+                '&': 'AMPERSAND',
+                ';': 'SEMI',
+                ',': 'COMMA',
+                '(': 'L_PAREN',
+                ')': 'R_PAREN',
+                '<': 'L_ANG',
+                '>': 'R_ANG',
+                '<=': 'LTE_ANG',
+                '>=': 'GTE_ANG',
+                '==': 'EQ',
+                '===': 'EQQ',
+                '{': 'L_BRACE',
+                '}': 'R_BRACE',
+                '[': 'L_BRACKET',
+                ']': 'R_BRACKET',
+                '=': 'EQUALS'
+            };
+            function isValidCSSClassChar(c) {
+                return isAlpha(c) || isNumeric(c) || c === "-" || c === "_";
+            }
+            function isValidCSSIDChar(c) {
+                return isAlpha(c) || isNumeric(c) || c === "-" || c === "_" || c === ":";
+            }
+            function isWhitespace(c) {
+                return c === " " || c === "\t" || isNewline(c);
+            }
+            function positionString(token) {
+                return "[Line: " + token.line + ", Column: " + token.col + "]";
+            }
+            function isNewline(c) {
+                return c === '\r' || c === '\n';
+            }
+            function isNumeric(c) {
+                return c >= '0' && c <= '9';
+            }
+            function isAlpha(c) {
+                return (c >= 'a' && c <= 'z') ||
+                    (c >= 'A' && c <= 'Z');
+            }
+            function makeTokensObject(tokens, consumed, source) {
+                var ignoreWhiteSpace = true;
+                matchTokenType("WHITESPACE"); // consume any initial whitespace
+                function raiseError(tokens, error) {
+                    _parser.raiseParseError(tokens, error);
                 }
-
-                function isValidCSSIDChar(c) {
-                    return isAlpha(c) || isNumeric(c) || c === "-" || c === "_" || c === ":";
-                }
-
-                function isWhitespace(c) {
-                    return c === " " || c === "\t" || isNewline(c);
-                }
-
-                function positionString(token) {
-                    return "[Line: " + token.line + ", Column: " + token.col + "]"
-                }
-
-                function isNewline(c) {
-                    return c === '\r' || c === '\n';
-                }
-
-                function isNumeric(c) {
-                    return c >= '0' && c <= '9';
-                }
-
-                function isAlpha(c) {
-                    return (c >= 'a' && c <= 'z') ||
-                        (c >= 'A' && c <= 'Z');
-                }
-
-
-                function makeTokensObject(tokens, consumed, source) {
-
-                    var ignoreWhiteSpace = true;
-                    matchTokenType("WHITESPACE"); // consume any initial whitespace
-
-                    function raiseError(tokens, error) {
-                        _parser.raiseParseError(tokens, error);
-                    }
-
-                    function requireOpToken(value) {
-                        var token = matchOpToken(value);
-                        if (token) {
-                            return token;
-                        } else {
-                            raiseError(this, "Expected '" + value + "' but found '" + currentToken().value + "'");
-                        }
-                    }
-
-                    function matchAnyOpToken(op1, op2, op3) {
-                        for (var i = 0; i < arguments.length; i++) {
-                            var opToken = arguments[i];
-                            var match = matchOpToken(opToken);
-                            if (match) {
-                                return match;
-                            }
-                        }
-                    }
-
-                    function matchOpToken(value) {
-                        if (currentToken() && currentToken().op && currentToken().value === value) {
-                            return consumeToken();
-                        }
-                    }
-
-                    function requireTokenType(type1, type2, type3, type4) {
-                        var token = matchTokenType(type1, type2, type3, type4);
-                        if (token) {
-                            return token;
-                        } else {
-                            raiseError(this, "Expected one of " + JSON.stringify([type1, type2, type3]));
-                        }
-                    }
-
-                    function matchTokenType(type1, type2, type3, type4) {
-                        if (currentToken() && currentToken().type && [type1, type2, type3, type4].indexOf(currentToken().type) >= 0) {
-                            return consumeToken();
-                        }
-                    }
-
-                    function requireToken(value, type) {
-                        var token = matchToken(value, type);
-                        if (token) {
-                            return token;
-                        } else {
-                            raiseError(this, "Expected '" + value + "' but found '" + currentToken().value + "'");
-                        }
-                    }
-
-                    function matchToken(value, type) {
-                        var type = type || "IDENTIFIER";
-                        if (currentToken() && currentToken().value === value && currentToken().type === type) {
-                            return consumeToken();
-                        }
-                    }
-
-                    function consumeToken() {
-                        var match = tokens.shift();
-                        consumed.push(match);
-                        if(ignoreWhiteSpace) {
-                            matchTokenType("WHITESPACE"); // consume any whitespace until the next token
-                        }
-                        return match;
-                    }
-
-                    function consumeUntilWhitespace() {
-                        var tokenList = [];
-                        ignoreWhiteSpace = false;
-                        while (currentToken() && currentToken().type !== "WHITESPACE") {
-                            tokenList.push(consumeToken());
-                        }
-                        ignoreWhiteSpace = true;
-                        return tokenList;
-                    }
-
-                    function hasMore() {
-                        return tokens.length > 0;
-                    }
-
-                    function currentToken() {
-                        return tokens[0];
-                    }
-
-                    return {
-                        matchAnyOpToken: matchAnyOpToken,
-                        matchOpToken: matchOpToken,
-                        requireOpToken: requireOpToken,
-                        matchTokenType: matchTokenType,
-                        requireTokenType: requireTokenType,
-                        consumeToken: consumeToken,
-                        matchToken: matchToken,
-                        requireToken: requireToken,
-                        list: tokens,
-                        source: source,
-                        hasMore: hasMore,
-                        currentToken: currentToken,
-                        consumeUntilWhitespace: consumeUntilWhitespace
-                    }
-                }
-
-                function tokenize(string) {
-                    var source = string;
-                    var tokens = [];
-                    var position = 0;
-                    var column = 0;
-                    var line = 1;
-                    var lastToken = "<START>";
-
-                    while (position < source.length) {
-                        if (currentChar() === "-" && nextChar() === "-") {
-                            consumeComment();
-                        } else {
-                            if (isWhitespace(currentChar())) {
-                                tokens.push(consumeWhitespace());
-                            } else if (!possiblePrecedingSymbol() && currentChar() === "." && isAlpha(nextChar())) {
-                                tokens.push(consumeClassReference());
-                            } else if (!possiblePrecedingSymbol() && currentChar() === "#" && isAlpha(nextChar())) {
-                                tokens.push(consumeIdReference());
-                            } else if (isAlpha(currentChar())) {
-                                tokens.push(consumeIdentifier());
-                            } else if (isNumeric(currentChar())) {
-                                tokens.push(consumeNumber());
-                            } else if (currentChar() === '"' || currentChar() === "'") {
-                                tokens.push(consumeString());
-                            } else if (OP_TABLE[currentChar()]) {
-                                tokens.push(consumeOp());
-                            } else {
-                                if (position < source.length) {
-                                    throw Error("Unknown token: " + currentChar() + " ");
-                                }
-                            }
-                        }
-                    }
-
-                    return makeTokensObject(tokens, [], source);
-
-                    function makeOpToken(type, value) {
-                        var token = makeToken(type, value);
-                        token.op = true;
+                function requireOpToken(value) {
+                    var token = matchOpToken(value);
+                    if (token) {
                         return token;
                     }
-
-                    function makeToken(type, value) {
-                        return {
-                            type: type,
-                            value: value,
-                            start: position,
-                            end: position + 1,
-                            column: column,
-                            line: line
-                        };
+                    else {
+                        raiseError(this, "Expected '" + value + "' but found '" + currentToken().value + "'");
                     }
-
-                    function consumeComment() {
-                        while (currentChar() && !isNewline(currentChar())) {
-                            consumeChar();
+                }
+                function matchAnyOpToken(op1, op2, op3) {
+                    for (var i = 0; i < arguments.length; i++) {
+                        var opToken = arguments[i];
+                        var match = matchOpToken(opToken);
+                        if (match) {
+                            return match;
                         }
+                    }
+                }
+                function matchOpToken(value) {
+                    if (currentToken() && currentToken().op && currentToken().value === value) {
+                        return consumeToken();
+                    }
+                }
+                function requireTokenType(type1, type2, type3, type4) {
+                    var token = matchTokenType(type1, type2, type3, type4);
+                    if (token) {
+                        return token;
+                    }
+                    else {
+                        raiseError(this, "Expected one of " + JSON.stringify([type1, type2, type3]));
+                    }
+                }
+                function matchTokenType(type1, type2, type3, type4) {
+                    if (currentToken() && currentToken().type && [type1, type2, type3, type4].indexOf(currentToken().type) >= 0) {
+                        return consumeToken();
+                    }
+                }
+                function requireToken(value, type) {
+                    var token = matchToken(value, type);
+                    if (token) {
+                        return token;
+                    }
+                    else {
+                        raiseError(this, "Expected '" + value + "' but found '" + currentToken().value + "'");
+                    }
+                }
+                function matchToken(value, type) {
+                    var _type = type || "IDENTIFIER";
+                    if (currentToken() && currentToken().value === value && currentToken().type === _type) {
+                        return consumeToken();
+                    }
+                }
+                function consumeToken() {
+                    var match = tokens.shift();
+                    consumed.push(match);
+                    if (ignoreWhiteSpace) {
+                        matchTokenType("WHITESPACE"); // consume any whitespace until the next token
+                    }
+                    return match;
+                }
+                function consumeUntilWhitespace() {
+                    var tokenList = [];
+                    ignoreWhiteSpace = false;
+                    while (currentToken() && currentToken().type !== "WHITESPACE") {
+                        tokenList.push(consumeToken());
+                    }
+                    ignoreWhiteSpace = true;
+                    return tokenList;
+                }
+                function hasMore() {
+                    return tokens.length > 0;
+                }
+                function currentToken() {
+                    return tokens[0];
+                }
+                return {
+                    matchAnyOpToken: matchAnyOpToken,
+                    matchOpToken: matchOpToken,
+                    requireOpToken: requireOpToken,
+                    matchTokenType: matchTokenType,
+                    requireTokenType: requireTokenType,
+                    consumeToken: consumeToken,
+                    matchToken: matchToken,
+                    requireToken: requireToken,
+                    list: tokens,
+                    source: source,
+                    hasMore: hasMore,
+                    currentToken: currentToken,
+                    consumeUntilWhitespace: consumeUntilWhitespace
+                };
+            }
+            function tokenize(string) {
+                var source = string;
+                var tokens = [];
+                var position = 0;
+                var column = 0;
+                var line = 1;
+                var lastToken = "<START>";
+                while (position < source.length) {
+                    if (currentChar() === "-" && nextChar() === "-") {
+                        consumeComment();
+                    }
+                    else {
+                        if (isWhitespace(currentChar())) {
+                            tokens.push(consumeWhitespace());
+                        }
+                        else if (!possiblePrecedingSymbol() && currentChar() === "." && isAlpha(nextChar())) {
+                            tokens.push(consumeClassReference());
+                        }
+                        else if (!possiblePrecedingSymbol() && currentChar() === "#" && isAlpha(nextChar())) {
+                            tokens.push(consumeIdReference());
+                        }
+                        else if (isAlpha(currentChar())) {
+                            tokens.push(consumeIdentifier());
+                        }
+                        else if (isNumeric(currentChar())) {
+                            tokens.push(consumeNumber());
+                        }
+                        else if (currentChar() === '"' || currentChar() === "'") {
+                            tokens.push(consumeString());
+                        }
+                        else if (OP_TABLE[currentChar()]) {
+                            tokens.push(consumeOp());
+                        }
+                        else {
+                            if (position < source.length) {
+                                throw Error("Unknown token: " + currentChar() + " ");
+                            }
+                        }
+                    }
+                }
+                return makeTokensObject(tokens, [], source);
+                function makeOpToken(type, value) {
+                    var token = makeToken(type, value);
+                    token.op = true;
+                    return token;
+                }
+                function makeToken(type, value) {
+                    return {
+                        type: type,
+                        value: value,
+                        start: position,
+                        end: position + 1,
+                        column: column,
+                        line: line
+                    };
+                }
+                function consumeComment() {
+                    while (currentChar() && !isNewline(currentChar())) {
                         consumeChar();
                     }
-
-                    function consumeClassReference() {
-                        var classRef = makeToken("CLASS_REF");
-                        var value = consumeChar();
-                        while (isValidCSSClassChar(currentChar())) {
-                            value += consumeChar();
-                        }
-                        classRef.value = value;
-                        classRef.end = position;
-                        return classRef;
+                    consumeChar();
+                }
+                function consumeClassReference() {
+                    var classRef = makeToken("CLASS_REF");
+                    var value = consumeChar();
+                    while (isValidCSSClassChar(currentChar())) {
+                        value += consumeChar();
                     }
-
-
-                    function consumeIdReference() {
-                        var idRef = makeToken("ID_REF");
-                        var value = consumeChar();
-                        while (isValidCSSIDChar(currentChar())) {
-                            value += consumeChar();
-                        }
-                        idRef.value = value;
-                        idRef.end = position;
-                        return idRef;
+                    classRef.value = value;
+                    classRef.end = position;
+                    return classRef;
+                }
+                function consumeIdReference() {
+                    var idRef = makeToken("ID_REF");
+                    var value = consumeChar();
+                    while (isValidCSSIDChar(currentChar())) {
+                        value += consumeChar();
                     }
-
-                    function consumeIdentifier() {
-                        var identifier = makeToken("IDENTIFIER");
-                        var value = consumeChar();
-                        while (isAlpha(currentChar())) {
-                            value += consumeChar();
-                        }
-                        identifier.value = value;
-                        identifier.end = position;
-                        return identifier;
+                    idRef.value = value;
+                    idRef.end = position;
+                    return idRef;
+                }
+                function consumeIdentifier() {
+                    var identifier = makeToken("IDENTIFIER");
+                    var value = consumeChar();
+                    while (isAlpha(currentChar())) {
+                        value += consumeChar();
                     }
-
-                    function consumeNumber() {
-                        var number = makeToken("NUMBER");
-                        var value = consumeChar();
-                        while (isNumeric(currentChar())) {
-                            value += consumeChar();
-                        }
-                        if (currentChar() === ".") {
-                            value += consumeChar();
-                        }
-                        while (isNumeric(currentChar())) {
-                            value += consumeChar();
-                        }
-                        number.value = value;
-                        number.end = position;
-                        return number;
+                    identifier.value = value;
+                    identifier.end = position;
+                    return identifier;
+                }
+                function consumeNumber() {
+                    var number = makeToken("NUMBER");
+                    var value = consumeChar();
+                    while (isNumeric(currentChar())) {
+                        value += consumeChar();
                     }
-
-                    function consumeOp() {
-                        var value = consumeChar(); // consume leading char
-                        while (currentChar() && OP_TABLE[value + currentChar()]) {
-                            value += consumeChar();
+                    if (currentChar() === ".") {
+                        value += consumeChar();
+                    }
+                    while (isNumeric(currentChar())) {
+                        value += consumeChar();
+                    }
+                    number.value = value;
+                    number.end = position;
+                    return number;
+                }
+                function consumeOp() {
+                    var value = consumeChar(); // consume leading char
+                    while (currentChar() && OP_TABLE[value + currentChar()]) {
+                        value += consumeChar();
+                    }
+                    var op = makeOpToken(OP_TABLE[value], value);
+                    op.value = value;
+                    op.end = position;
+                    return op;
+                }
+                function consumeString() {
+                    var string = makeToken("STRING");
+                    var startChar = consumeChar(); // consume leading quote
+                    var value = "";
+                    while (currentChar() && currentChar() !== startChar) {
+                        if (currentChar() === "\\") {
+                            consumeChar(); // consume escape char and move on
                         }
-                        var op = makeOpToken(OP_TABLE[value], value);
-                        op.value = value;
-                        op.end = position;
-                        return op;
+                        value += consumeChar();
                     }
-
-                    function consumeString() {
-                        var string = makeToken("STRING");
-                        var startChar = consumeChar(); // consume leading quote
-                        var value = "";
-                        while (currentChar() && currentChar() !== startChar) {
-                            if (currentChar() === "\\") {
-                                consumeChar(); // consume escape char and move on
-                            }
-                            value += consumeChar();
+                    if (currentChar() !== startChar) {
+                        throw Error("Unterminated string at " + positionString(string));
+                    }
+                    else {
+                        consumeChar(); // consume final quote
+                    }
+                    string.value = value;
+                    string.end = position;
+                    return string;
+                }
+                function currentChar() {
+                    return source.charAt(position);
+                }
+                function nextChar() {
+                    return source.charAt(position + 1);
+                }
+                function consumeChar() {
+                    lastToken = currentChar();
+                    position++;
+                    column++;
+                    return lastToken;
+                }
+                function possiblePrecedingSymbol() {
+                    return isAlpha(lastToken) || isNumeric(lastToken) || lastToken === ")" || lastToken === "}" || lastToken === "]";
+                }
+                function consumeWhitespace() {
+                    var whitespace = makeToken("WHITESPACE");
+                    var value = "";
+                    while (currentChar() && isWhitespace(currentChar())) {
+                        if (isNewline(currentChar())) {
+                            column = 0;
+                            line++;
                         }
-                        if (currentChar() !== startChar) {
-                            throw Error("Unterminated string at " + positionString(string));
-                        } else {
-                            consumeChar(); // consume final quote
-                        }
-                        string.value = value;
-                        string.end = position;
-                        return string;
+                        value += consumeChar();
                     }
-
-                    function currentChar() {
-                        return source.charAt(position);
-                    }
-
-                    function nextChar() {
-                        return source.charAt(position + 1);
-                    }
-
-                    function consumeChar() {
-                        lastToken = currentChar();
-                        position++;
-                        column++;
-                        return lastToken;
-                    }
-
-                    function possiblePrecedingSymbol() {
-                        return isAlpha(lastToken) || isNumeric(lastToken) || lastToken === ")" || lastToken === "}" || lastToken === "]"
-                    }
-
-                    function consumeWhitespace() {
-                        var whitespace = makeToken("WHITESPACE");
-                        var value = "";
-                        while (currentChar() && isWhitespace(currentChar())) {
-                            if (isNewline(currentChar())) {
-                                column = 0;
-                                line++;
-                            }
-                            value += consumeChar();
-                        }
-                        whitespace.value = value;
-                        whitespace.end = position;
-                        return whitespace;
+                    whitespace.value = value;
+                    whitespace.end = position;
+                    return whitespace;
+                }
+            }
+            return {
+                tokenize: tokenize
+            };
+        }();
+        //-----------------------------------------------
+        // Parser
+        //-----------------------------------------------
+        var _parser = function () {
+            var GRAMMAR = {};
+            function addGrammarElement(name, definition) {
+                GRAMMAR[name] = definition;
+            }
+            function createParserContext(tokens) {
+                var currentToken = tokens.currentToken();
+                var source = tokens.source;
+                var lines = source.split("\n");
+                var line = currentToken ? currentToken.line - 1 : lines.length - 1;
+                var contextLine = lines[line];
+                var offset = currentToken ? currentToken.column : contextLine.length - 1;
+                return contextLine + "\n" + " ".repeat(offset) + "^^\n\n";
+            }
+            function raiseParseError(tokens, message) {
+                message = (message || "Unexpected Token : " + tokens.currentToken().value) + "\n\n" +
+                    createParserContext(tokens);
+                var error = new Error(message);
+                error.tokens = tokens;
+                throw error;
+            }
+            function parseElement(type, tokens, root) {
+                var expressionDef = GRAMMAR[type];
+                if (expressionDef)
+                    return expressionDef(_parser, tokens, root);
+            }
+            function parseAnyOf(types, tokens) {
+                for (var i = 0; i < types.length; i++) {
+                    var type = types[i];
+                    var expression = parseElement(type, tokens);
+                    if (expression) {
+                        return expression;
                     }
                 }
-
+            }
+            function parseHyperScript(tokens) {
+                return parseElement("hyperscript", tokens);
+            }
+            function transpile(node, defaultVal) {
+                if (node == null) {
+                    return defaultVal;
+                }
+                var src = node.transpile();
+                if (node.next) {
+                    return src + "\n" + transpile(node.next);
+                }
+                else {
+                    return src;
+                }
+            }
+            return {
+                // parser API
+                parseElement: parseElement,
+                parseAnyOf: parseAnyOf,
+                parseHyperScript: parseHyperScript,
+                raiseParseError: raiseParseError,
+                addGrammarElement: addGrammarElement,
+                transpile: transpile
+            };
+        }();
+        //-----------------------------------------------
+        // Runtime
+        //-----------------------------------------------
+        var _runtime = function () {
+            var SCRIPT_ATTRIBUTES = ["_", "script", "data-script"];
+            function matchesSelector(elt, selector) {
+                // noinspection JSUnresolvedVariable
+                var matchesFunction = elt.matches ||
+                    elt.matchesSelector || elt.msMatchesSelector || elt.mozMatchesSelector
+                    || elt.webkitMatchesSelector || elt.oMatchesSelector;
+                return matchesFunction && matchesFunction.call(elt, selector);
+            }
+            function makeEvent(eventName, detail) {
+                var evt;
+                if (window.CustomEvent && typeof window.CustomEvent === 'function') {
+                    evt = new CustomEvent(eventName, { bubbles: true, cancelable: true, detail: detail });
+                }
+                else {
+                    evt = document.createEvent('CustomEvent');
+                    evt.initCustomEvent(eventName, true, true, detail);
+                }
+                return evt;
+            }
+            function triggerEvent(elt, eventName, detail) {
+                var detail = detail || {};
+                detail["sentBy"] = elt;
+                var event = makeEvent(eventName, detail);
+                var eventResult = elt.dispatchEvent(event);
+                return eventResult;
+            }
+            function forEach(arr, func) {
+                if (arr.length) {
+                    for (var i = 0; i < arr.length; i++) {
+                        func(arr[i]);
+                    }
+                }
+                else {
+                    func(arr);
+                }
+            }
+            function evalTarget(root, path) {
+                if (root.length) {
+                    var last = root;
+                }
+                else {
+                    var last = [root];
+                }
+                while (path.length > 0) {
+                    var prop = path.shift();
+                    var next = [];
+                    // flat map
+                    for (var i = 0; i < last.length; i++) {
+                        var element = last[i];
+                        var nextVal = element[prop];
+                        if (nextVal && nextVal.length) {
+                            next = next.concat(nextVal);
+                        }
+                        else {
+                            next.push(nextVal);
+                        }
+                    }
+                    last = next;
+                }
+                return last;
+            }
+            function getScript(elt) {
+                for (var i = 0; i < SCRIPT_ATTRIBUTES.length; i++) {
+                    var scriptAttribute = SCRIPT_ATTRIBUTES[i];
+                    if (elt.hasAttribute && elt.hasAttribute(scriptAttribute)) {
+                        return elt.getAttribute(scriptAttribute);
+                    }
+                }
+                return null;
+            }
+            function applyEventListeners(hypeScript, elt) {
+                forEach(hypeScript.eventListeners, function (eventListener) {
+                    eventListener(elt);
+                });
+            }
+            function setScriptAttrs(values) {
+                SCRIPT_ATTRIBUTES = values;
+            }
+            function getScriptSelector() {
+                return SCRIPT_ATTRIBUTES.map(function (attribute) {
+                    return "[" + attribute + "]";
+                }).join(", ");
+            }
+            function isType(o, type) {
+                return Object.prototype.toString.call(o) === "[object " + type + "]";
+            }
+            function evaluate(typeOrSrc, srcOrCtx, ctxArg) {
+                if (isType(srcOrCtx, "Object")) {
+                    var src = typeOrSrc;
+                    var ctx = srcOrCtx;
+                    var type = "expression";
+                }
+                else if (isType(srcOrCtx, "String")) {
+                    var src = srcOrCtx;
+                    var type = typeOrSrc;
+                    var ctx = ctxArg;
+                }
+                else {
+                    var src = typeOrSrc;
+                    var ctx = {};
+                    var type = "expression";
+                }
+                ctx = ctx || {};
+                var compiled = _parser.parseElement(type, _lexer.tokenize(src)).transpile();
+                var evalString = "(function(" + Object.keys(ctx).join(",") + "){return " + compiled + "})";
+                var args = Object.keys(ctx).map(function (key) {
+                    return ctx[key];
+                });
+                return eval(evalString).apply(null, args);
+            }
+            function initElement(elt) {
+                var src = getScript(elt);
+                if (src) {
+                    var tokens = _lexer.tokenize(src);
+                    var hyperScript = _parser.parseHyperScript(tokens);
+                    var transpiled = _parser.transpile(hyperScript);
+                    if (elt.getAttribute('debug') === "true") {
+                        console.log(transpiled);
+                    }
+                    var hyperscriptObj = eval(transpiled);
+                    hyperscriptObj.applyEventListenersTo(elt);
+                }
+            }
+            function ajax(method, url, callback, data) {
+                var xhr = new XMLHttpRequest();
+                xhr.onload = function () {
+                    callback(this.response, xhr);
+                };
+                xhr.open(method, url);
+                xhr.send(JSON.stringify(data));
+            }
+            function typeCheck(value, typeString, nullOk) {
+                if (value == null && nullOk) {
+                    return value;
+                }
+                var typeName = Object.prototype.toString.call(value).slice(8, -1);
+                var typeCheckValue = value && typeName === typeString;
+                if (typeCheckValue) {
+                    return value;
+                }
+                else {
+                    throw new Error("Typecheck failed!  Expected: " + typeString + ", Found: " + typeName);
+                }
+            }
+            return {
+                typeCheck: typeCheck,
+                forEach: forEach,
+                evalTarget: evalTarget,
+                triggerEvent: triggerEvent,
+                matchesSelector: matchesSelector,
+                getScript: getScript,
+                applyEventListeners: applyEventListeners,
+                setScriptAttrs: setScriptAttrs,
+                initElement: initElement,
+                evaluate: evaluate,
+                getScriptSelector: getScriptSelector,
+                ajax: ajax,
+            };
+        }();
+        //-----------------------------------------------
+        // Expressions
+        //-----------------------------------------------
+        _parser.addGrammarElement("parenthesized", function (parser, tokens) {
+            if (tokens.matchOpToken('(')) {
+                var expr = parser.parseElement("expression", tokens);
+                tokens.requireOpToken(")");
                 return {
-                    tokenize: tokenize
-                }
-            }();
-
-            //-----------------------------------------------
-            // Parser
-            //-----------------------------------------------
-            var _parser = function () {
-
-                var GRAMMAR = {}
-
-                function addGrammarElement(name, definition) {
-                    GRAMMAR[name] = definition;
-                }
-
-                function createParserContext(tokens) {
-                    var currentToken = tokens.currentToken();
-                    var source = tokens.source;
-                    var lines = source.split("\n");
-                    var line = currentToken ? currentToken.line - 1 : lines.length - 1;
-                    var contextLine = lines[line];
-                    var offset = currentToken ? currentToken.column : contextLine.length - 1;
-                    return contextLine + "\n" + " ".repeat(offset) + "^^\n\n";
-                }
-
-                function raiseParseError(tokens, message) {
-                    message = (message || "Unexpected Token : " + tokens.currentToken().value) + "\n\n" +
-                        createParserContext(tokens);
-                    var error = new Error(message);
-                    error.tokens = tokens;
-                    throw error
-                }
-
-                function parseElement(type, tokens, root) {
-                    var expressionDef = GRAMMAR[type];
-                    if (expressionDef) return expressionDef(_parser, tokens, root);
-                }
-
-                function parseAnyOf(types, tokens) {
-                    for (var i = 0; i < types.length; i++) {
-                        var type = types[i];
-                        var expression = parseElement(type, tokens);
-                        if (expression) {
-                            return expression;
-                        }
-                    }
-                }
-
-                function parseHyperScript(tokens) {
-                    return parseElement("hyperscript", tokens)
-                }
-
-                function transpile(node, defaultVal) {
-                    if (node == null) {
-                        return defaultVal;
-                    }
-                    var src = node.transpile();
-                    if (node.next) {
-                        return src + "\n" + transpile(node.next)
-                    } else {
-                        return src;
-                    }
-                }
-
-                return {
-                    // parser API
-                    parseElement: parseElement,
-                    parseAnyOf: parseAnyOf,
-                    parseHyperScript: parseHyperScript,
-                    raiseParseError: raiseParseError,
-                    addGrammarElement: addGrammarElement,
-                    transpile: transpile
-                }
-            }();
-
-            //-----------------------------------------------
-            // Runtime
-            //-----------------------------------------------
-            var _runtime = function () {
-                var SCRIPT_ATTRIBUTES = ["_", "script", "data-script"];
-
-                function matchesSelector(elt, selector) {
-                    // noinspection JSUnresolvedVariable
-                    var matchesFunction = elt.matches ||
-                        elt.matchesSelector || elt.msMatchesSelector || elt.mozMatchesSelector
-                        || elt.webkitMatchesSelector || elt.oMatchesSelector;
-                    return matchesFunction && matchesFunction.call(elt, selector);
-                }
-
-                function makeEvent(eventName, detail) {
-                    var evt;
-                    if (window.CustomEvent && typeof window.CustomEvent === 'function') {
-                        evt = new CustomEvent(eventName, {bubbles: true, cancelable: true, detail: detail});
-                    } else {
-                        evt = document.createEvent('CustomEvent');
-                        evt.initCustomEvent(eventName, true, true, detail);
-                    }
-                    return evt;
-                }
-
-                function triggerEvent(elt, eventName, detail) {
-                    var detail = detail || {};
-                    detail["sentBy"] = elt;
-                    var event = makeEvent(eventName, detail);
-                    var eventResult = elt.dispatchEvent(event);
-                    return eventResult;
-                }
-
-                function forEach(arr, func) {
-                    if (arr.length) {
-                        for (var i = 0; i < arr.length; i++) {
-                            func(arr[i]);
-                        }
-                    } else {
-                        func(arr);
-                    }
-                }
-
-                function evalTarget(root, path) {
-                    if (root.length) {
-                        var last = root;
-                    } else {
-                        var last = [root];
-                    }
-
-                    while (path.length > 0) {
-                        var prop = path.shift();
-                        var next = []
-                        // flat map
-                        for (var i = 0; i < last.length; i++) {
-                            var element = last[i];
-                            var nextVal = element[prop];
-                            if (nextVal && nextVal.length) {
-                                next = next.concat(nextVal);
-                            } else {
-                                next.push(nextVal);
-                            }
-                        }
-                        last = next;
-                    }
-
-                    return last;
-                }
-
-                function getScript(elt) {
-                    for (var i = 0; i < SCRIPT_ATTRIBUTES.length; i++) {
-                        var scriptAttribute = SCRIPT_ATTRIBUTES[i];
-                        if (elt.hasAttribute && elt.hasAttribute(scriptAttribute)) {
-                            return elt.getAttribute(scriptAttribute)
-                        }
-                    }
-                    return null;
-                }
-
-                function applyEventListeners(hypeScript, elt) {
-                    forEach(hypeScript.eventListeners, function (eventListener) {
-                        eventListener(elt);
-                    });
-                }
-
-                function setScriptAttrs(values) {
-                    SCRIPT_ATTRIBUTES = values;
-                }
-
-                function getScriptSelector() {
-                    return SCRIPT_ATTRIBUTES.map(function (attribute) {
-                        return "[" + attribute + "]";
-                    }).join(", ");
-                }
-
-                function isType(o, type) {
-                    return Object.prototype.toString.call(o) === "[object " + type + "]";
-                }
-
-                function evaluate(typeOrSrc, srcOrCtx, ctxArg) {
-                    if (isType(srcOrCtx, "Object")) {
-                        var src = typeOrSrc;
-                        var ctx = srcOrCtx;
-                        var type = "expression"
-                    } else if (isType(srcOrCtx, "String")) {
-                        var src = srcOrCtx;
-                        var type = typeOrSrc
-                        var ctx = ctxArg;
-                    } else {
-                        var src = typeOrSrc;
-                        var ctx = {};
-                        var type = "expression";
-                    }
-                    ctx = ctx || {};
-                    var compiled = _parser.parseElement(type, _lexer.tokenize(src) ).transpile();
-                    var evalString = "(function(" + Object.keys(ctx).join(",") + "){return " + compiled + "})";
-                    var args = Object.keys(ctx).map(function (key) {
-                        return ctx[key]
-                    });
-                    return eval(evalString).apply(null, args);
-                }
-
-                function initElement(elt) {
-                    var src = getScript(elt);
-                    if (src) {
-                        var tokens = _lexer.tokenize(src);
-                        var hyperScript = _parser.parseHyperScript(tokens);
-                        var transpiled = _parser.transpile(hyperScript);
-                        if (elt.getAttribute('debug') === "true") {
-                            console.log(transpiled);
-                        }
-                        var hyperscriptObj = eval(transpiled);
-                        hyperscriptObj.applyEventListenersTo(elt);
-                    }
-                }
-
-                function ajax(method, url, callback, data) {
-                    var xhr = new XMLHttpRequest();
-                    xhr.onload = function() {
-                        callback(this.response, xhr);
-                    };
-                    xhr.open(method, url);
-                    xhr.send(JSON.stringify(data));
-                }
-
-                function typeCheck(value, typeString, nullOk) {
-                    if (value == null && nullOk) {
-                        return value;
-                    }
-                    var typeName = Object.prototype.toString.call(value).slice(8, -1);
-                    var typeCheckValue = value && typeName === typeString;
-                    if (typeCheckValue) {
-                        return value;
-                    } else {
-                        throw new Error("Typecheck failed!  Expected: " + typeString + ", Found: " + typeName);
-                    }
-                }
-
-                return {
-                    typeCheck: typeCheck,
-                    forEach: forEach,
-                    evalTarget: evalTarget,
-                    triggerEvent: triggerEvent,
-                    matchesSelector: matchesSelector,
-                    getScript: getScript,
-                    applyEventListeners: applyEventListeners,
-                    setScriptAttrs: setScriptAttrs,
-                    initElement: initElement,
-                    evaluate: evaluate,
-                    getScriptSelector: getScriptSelector,
-                    ajax: ajax,
-                }
-            }();
-
-            //-----------------------------------------------
-            // Expressions
-            //-----------------------------------------------
-
-            _parser.addGrammarElement("parenthesized", function (parser, tokens) {
-                if (tokens.matchOpToken('(')) {
-                    var expr = parser.parseElement("expression", tokens);
-                    tokens.requireOpToken(")");
-                    return {
-                        type: "parenthesized",
-                        expr: expr,
-                        transpile: function () {
-                            return "(" + parser.transpile(expr) + ")";
-                        }
-                    }
-                }
-            })
-
-            _parser.addGrammarElement("string", function (parser, tokens) {
-                var stringToken = tokens.matchTokenType('STRING');
-                if (stringToken) {
-                    return {
-                        type: "string",
-                        token: stringToken,
-                        transpile: function () {
-                            if (stringToken.value.indexOf("'") === 0) {
-                                return "'" + stringToken.value + "'";
-                            } else {
-                                return '"' + stringToken.value + '"';
-                            }
-                        }
-                    }
-                }
-            })
-
-            _parser.addGrammarElement("nakedString", function (parser, tokens) {
-                if (tokens.hasMore()) {
-                    var tokenArr = tokens.consumeUntilWhitespace();
-                    tokens.matchTokenType("WHITESPACE");
-                    return {
-                        type: "nakedString",
-                        tokens: tokenArr,
-                        transpile: function () {
-                                return "'" + tokenArr.map(function(t){return t.value}).join("") + "'";
-                        }
-                    }
-                }
-            })
-
-            _parser.addGrammarElement("number", function (parser, tokens) {
-                var number = tokens.matchTokenType('NUMBER');
-                if (number) {
-                    var numberToken = number;
-                    var value = parseFloat(number.value)
-                    return {
-                        type: "number",
-                        value: value,
-                        numberToken: numberToken,
-                        transpile: function () {
-                            return numberToken.value;
-                        }
-                    }
-                }
-            })
-
-            _parser.addGrammarElement("idRef", function (parser, tokens) {
-                var elementId = tokens.matchTokenType('ID_REF');
-                if (elementId) {
-                    return {
-                        type: "idRef",
-                        value: elementId.value.substr(1),
-                        transpile: function () {
-                            return "document.getElementById('" + this.value + "')"
-                        }
-                    };
-                }
-            })
-
-            _parser.addGrammarElement("classRef", function (parser, tokens) {
-                var classRef = tokens.matchTokenType('CLASS_REF');
-                if (classRef) {
-                    return {
-                        type: "classRef",
-                        value: classRef.value,
-                        className: function () {
-                            return this.value.substr(1);
-                        },
-                        transpile: function () {
-                            return "document.querySelectorAll('" + this.value + "')"
-                        }
-                    };
-                }
-            })
-
-            _parser.addGrammarElement("attributeRef", function (parser, tokens) {
-                if (tokens.matchOpToken("[")) {
-                    var name = tokens.matchTokenType("IDENTIFIER");
-                    var value = null;
-                    if (tokens.matchOpToken("=")) {
-                        value = parser.parseElement("expression", tokens);
-                    }
-                    tokens.requireOpToken("]");
-                    return {
-                        type: "attribute_expression",
-                        name: name.value,
-                        value: value,
-                        transpile: function () {
-                            if (this.value) {
-                                return "({name: '" + this.name + "', value: " + parser.transpile(this.value) + "})";
-                            } else {
-                                return "({name: '" + this.name + "'})";
-                            }
-                        }
-                    }
-                }
-            })
-
-            _parser.addGrammarElement("objectLiteral", function (parser, tokens) {
-                if (tokens.matchOpToken("{")) {
-                    var fields = []
-                    if (!tokens.matchOpToken("}")) {
-                        do {
-                            var name = tokens.requireTokenType("IDENTIFIER");
-                            tokens.requireOpToken(":");
-                            var value = parser.parseElement("expression", tokens);
-                            fields.push({name: name, value: value});
-                        } while (tokens.matchOpToken(","))
-                        tokens.requireOpToken("}");
-                    }
-                    return {
-                        type: "objectLiteral",
-                        fields: fields,
-                        transpile: function () {
-                            return "({" + fields.map(function (field) {
-                                return field.name.value + ":" + parser.transpile(field.value)
-                            }).join(", ") + "})";
-                        }
-                    }
-                }
-
-
-            })
-
-            _parser.addGrammarElement("namedArgumentList", function (parser, tokens) {
-                if (tokens.matchOpToken("(")) {
-                    var fields = []
-                    if (!tokens.matchOpToken(")")) {
-                        do {
-                            var name = tokens.requireTokenType("IDENTIFIER");
-                            tokens.requireOpToken(":");
-                            var value = parser.parseElement("expression", tokens);
-                            fields.push({name: name, value: value});
-                        } while (tokens.matchOpToken(","))
-                        tokens.requireOpToken(")");
-                    }
-                    return {
-                        type: "namedArgumentList",
-                        fields: fields,
-                        transpile: function () {
-                            return "({_namedArgList_:true, " + fields.map(function (field) {
-                                return field.name.value + ":" + parser.transpile(field.value)
-                            }).join(", ") + "})";
-                        }
-                    }
-                }
-
-
-            })
-
-            _parser.addGrammarElement("symbol", function (parser, tokens) {
-                var identifier = tokens.matchTokenType('IDENTIFIER');
-                if (identifier) {
-                    return {
-                        type: "symbol",
-                        name: identifier.value,
-                        transpile: function () {
-                            return identifier.value;
-                        }
-                    };
-                }
-            });
-
-            _parser.addGrammarElement("implicitMeTarget", function (parser, tokens) {
-                return {
-                    type: "implicitMeTarget",
+                    type: "parenthesized",
+                    expr: expr,
                     transpile: function () {
-                        return "[me]"
+                        return "(" + parser.transpile(expr) + ")";
                     }
                 };
-            });
-
-            _parser.addGrammarElement("implicitAllTarget", function (parser, tokens) {
+            }
+        });
+        _parser.addGrammarElement("string", function (parser, tokens) {
+            var stringToken = tokens.matchTokenType('STRING');
+            if (stringToken) {
                 return {
-                    type: "implicitAllTarget",
+                    type: "string",
+                    token: stringToken,
                     transpile: function () {
-                        return 'document.querySelectorAll("*")';
+                        if (stringToken.value.indexOf("'") === 0) {
+                            return "'" + stringToken.value + "'";
+                        }
+                        else {
+                            return '"' + stringToken.value + '"';
+                        }
                     }
                 };
-            });
-
-            _parser.addGrammarElement("millisecondLiteral", function (parser, tokens) {
-                var number = tokens.requireTokenType(tokens, "NUMBER");
-                var factor = 1;
-                if (tokens.matchToken("s")) {
-                    factor = 1000;
-                } else if (tokens.matchToken("ms")) {
-                    // do nothing
-                }
+            }
+        });
+        _parser.addGrammarElement("nakedString", function (parser, tokens) {
+            if (tokens.hasMore()) {
+                var tokenArr = tokens.consumeUntilWhitespace();
+                tokens.matchTokenType("WHITESPACE");
                 return {
-                    type: "millisecondLiteral",
-                    number: number,
-                    factor: factor,
+                    type: "nakedString",
+                    tokens: tokenArr,
                     transpile: function () {
-                        return factor * parseFloat(this.number.value);
+                        return "'" + tokenArr.map(function (t) { return t.value; }).join("") + "'";
                     }
                 };
-            });
-
-            _parser.addGrammarElement("boolean", function (parser, tokens) {
-                var booleanLiteral = tokens.matchToken("true") || tokens.matchToken("false");
-                if (booleanLiteral) {
-                    return {
-                        type: "boolean",
-                        transpile: function () {
-                            return booleanLiteral.value;
-                        }
+            }
+        });
+        _parser.addGrammarElement("number", function (parser, tokens) {
+            var number = tokens.matchTokenType('NUMBER');
+            if (number) {
+                var numberToken = number;
+                var value = parseFloat(number.value);
+                return {
+                    type: "number",
+                    value: value,
+                    numberToken: numberToken,
+                    transpile: function () {
+                        return numberToken.value;
                     }
+                };
+            }
+        });
+        _parser.addGrammarElement("idRef", function (parser, tokens) {
+            var elementId = tokens.matchTokenType('ID_REF');
+            if (elementId) {
+                return {
+                    type: "idRef",
+                    value: elementId.value.substr(1),
+                    transpile: function () {
+                        return "document.getElementById('" + this.value + "')";
+                    }
+                };
+            }
+        });
+        _parser.addGrammarElement("classRef", function (parser, tokens) {
+            var classRef = tokens.matchTokenType('CLASS_REF');
+            if (classRef) {
+                return {
+                    type: "classRef",
+                    value: classRef.value,
+                    className: function () {
+                        return this.value.substr(1);
+                    },
+                    transpile: function () {
+                        return "document.querySelectorAll('" + this.value + "')";
+                    }
+                };
+            }
+        });
+        _parser.addGrammarElement("attributeRef", function (parser, tokens) {
+            if (tokens.matchOpToken("[")) {
+                var name = tokens.matchTokenType("IDENTIFIER");
+                var value = null;
+                if (tokens.matchOpToken("=")) {
+                    value = parser.parseElement("expression", tokens);
                 }
-            });
-
-            _parser.addGrammarElement("null", function (parser, tokens) {
-                if (tokens.matchToken('null')) {
-                    return {
-                        type: "null",
-                        transpile: function () {
-                            return "null";
+                tokens.requireOpToken("]");
+                return {
+                    type: "attribute_expression",
+                    name: name.value,
+                    value: value,
+                    transpile: function () {
+                        if (this.value) {
+                            return "({name: '" + this.name + "', value: " + parser.transpile(this.value) + "})";
+                        }
+                        else {
+                            return "({name: '" + this.name + "'})";
                         }
                     }
-                }
-            });
-
-            _parser.addGrammarElement("arrayLiteral", function (parser, tokens) {
-                if (tokens.matchOpToken('[')) {
-                    var values = [];
-                    if (!tokens.matchOpToken(']')) {
-                        do {
-                            var expr = parser.parseElement("expression", tokens);
-                            if (expr == null) {
-                                parser.raiseParseError(tokens, "Expected an expression");
-                            }
-                            values.push(expr);
-                        } while(tokens.matchOpToken(","))
-                        tokens.requireOpToken("]");
-                    }
-                    return {
-                        type: "arrayLiteral",
-                        values:values,
-                        transpile: function () {
-                            return "[" + values.map(function(v){ return parser.transpile(v) }).join(", ") + "]";
-                        }
-                    }
-                }
-            });
-
-            _parser.addGrammarElement("blockLiteral", function (parser, tokens) {
-                if (tokens.matchOpToken('\\')) {
-                    var args = []
-                    var arg1 = tokens.matchTokenType("IDENTIFIER");
-                    if (arg1) {
-                        args.push(arg1);
-                        while (tokens.matchOpToken(",")) {
-                            args.push(tokens.requireTokenType("IDENTIFIER"));
-                        }
-                    }
-                    // TODO compound op token
-                    tokens.requireOpToken("-");
-                    tokens.requireOpToken(">");
-                    var expr = parser.parseElement("expression", tokens);
-                    if (expr == null) {
-                        parser.raiseParseError(tokens, "Expected an expression");
-                    }
-                    return {
-                        type: "blockLiteral",
-                        args: args,
-                        expr: expr,
-                        transpile: function () {
-                            return "function(" + args.map(function (arg) {
-                                    return arg.value
-                                }).join(", ") + "){ return " +
-                                parser.transpile(expr) + " }";
-                        }
-                    }
-                }
-            });
-
-            _parser.addGrammarElement("leaf", function (parser, tokens) {
-                return parser.parseAnyOf(["parenthesized", "boolean", "null", "string", "number", "idRef", "classRef", "symbol", "propertyRef", "objectLiteral", "arrayLiteral", "blockLiteral"], tokens)
-            });
-
-            _parser.addGrammarElement("propertyAccess", function (parser, tokens, root) {
-                if (tokens.matchOpToken(".")) {
-                    var prop = tokens.requireTokenType("IDENTIFIER");
-                    var propertyAccess = {
-                        type: "propertyAccess",
-                        root: root,
-                        prop: prop,
-                        transpile: function () {
-                            return parser.transpile(root) + "." + prop.value;
-                        }
-                    };
-                    return _parser.parseElement("indirectExpression", tokens, propertyAccess);
-                }
-            });
-
-            _parser.addGrammarElement("functionCall", function (parser, tokens, root) {
-                if (tokens.matchOpToken("(")) {
-                    var args = [];
+                };
+            }
+        });
+        _parser.addGrammarElement("objectLiteral", function (parser, tokens) {
+            if (tokens.matchOpToken("{")) {
+                var fields = [];
+                if (!tokens.matchOpToken("}")) {
                     do {
-                        args.push(parser.parseElement("expression", tokens));
-                    } while (tokens.matchOpToken(","))
-                    tokens.requireOpToken(")");
-                    var functionCall = {
-                        type: "functionCall",
-                        root: root,
-                        args: args,
-                        transpile: function () {
-                            return parser.transpile(root) + "(" + args.map(function (arg) {
-                                return parser.transpile(arg)
-                            }).join(",") + ")"
-                        }
-                    };
-                    return _parser.parseElement("indirectExpression", tokens, functionCall);
+                        var name = tokens.requireTokenType("IDENTIFIER");
+                        tokens.requireOpToken(":");
+                        var value = parser.parseElement("expression", tokens);
+                        fields.push({ name: name, value: value });
+                    } while (tokens.matchOpToken(","));
+                    tokens.requireOpToken("}");
                 }
-            });
-
-            _parser.addGrammarElement("indirectExpression", function (parser, tokens, root) {
-                var propAccess = parser.parseElement("propertyAccess", tokens, root);
-                if (propAccess) {
-                    return propAccess;
-                }
-
-                var functionCall = parser.parseElement("functionCall", tokens, root);
-                if (functionCall) {
-                    return functionCall;
-                }
-
-                return root;
-            });
-
-            _parser.addGrammarElement("primaryExpression", function (parser, tokens) {
-                var leaf = parser.parseElement("leaf", tokens);
-                if (leaf) {
-                    return parser.parseElement("indirectExpression", tokens, leaf);
-                }
-                parser.raiseParseError(tokens, "Unexpected value: " + tokens.currentToken().value);
-            });
-
-            _parser.addGrammarElement("postfixExpression", function (parser, tokens) {
-                var root = parser.parseElement("primaryExpression", tokens);
-                if (tokens.matchOpToken(":")) {
-                    var typeName = tokens.requireTokenType("IDENTIFIER");
-                    var nullOk = !tokens.matchOpToken("!");
-                    return {
-                        type: "typeCheck",
-                        typeName: typeName,
-                        root: root,
-                        nullOk: nullOk,
-                        transpile: function () {
-                            return "_hyperscript.runtime.typeCheck(" + parser.transpile(root) + ", '" + typeName.value + "', " + nullOk + ")";
-                        }
-                    }
-                } else {
-                    return root;
-                }
-            });
-
-            _parser.addGrammarElement("logicalNot", function (parser, tokens) {
-                if (tokens.matchToken("not")) {
-                    var root = parser.parseElement("unaryExpression", tokens);
-                    return {
-                        type: "logicalNot",
-                        root: root,
-                        transpile: function () {
-                            return "!" + parser.transpile(root);
-                        }
-                    };
-                }
-            });
-
-            _parser.addGrammarElement("negativeNumber", function (parser, tokens) {
-                if (tokens.matchOpToken("-")) {
-                    var root = parser.parseElement("unaryExpression", tokens);
-                    return {
-                        type: "negativeNumber",
-                        root: root,
-                        transpile: function () {
-                            return "-" + parser.transpile(root);
-                        }
-                    };
-                }
-            });
-
-            _parser.addGrammarElement("unaryExpression", function (parser, tokens) {
-                return parser.parseAnyOf(["logicalNot", "negativeNumber", "postfixExpression"], tokens);
-            });
-
-            _parser.addGrammarElement("mathOperator", function (parser, tokens) {
-                var expr = parser.parseElement("unaryExpression", tokens);
-                var mathOp, initialMathOp = null;
-                mathOp = tokens.matchAnyOpToken("+", "-", "*", "/", "%")
-                while (mathOp) {
-                    initialMathOp = initialMathOp || mathOp;
-                    if(initialMathOp.value !== mathOp.value) {
-                        parser.raiseParseError(tokens, "You must parenthesize math operations with different operators")
-                    }
-                    var rhs = parser.parseElement("unaryExpression", tokens);
-                    expr = {
-                        type: "mathOperator",
-                        operator: mathOp.value,
-                        lhs: expr,
-                        rhs: rhs,
-                        transpile: function () {
-                            return parser.transpile(this.lhs) + " " + this.operator + " " + parser.transpile(this.rhs);
-                        }
-                    }
-                    mathOp = tokens.matchAnyOpToken("+", "-", "*", "/", "%")
-                }
-                return expr;
-            });
-
-            _parser.addGrammarElement("mathExpression", function (parser, tokens) {
-                return parser.parseAnyOf(["mathOperator", "unaryExpression"], tokens);
-            });
-
-            _parser.addGrammarElement("comparisonOperator", function (parser, tokens) {
-                var expr = parser.parseElement("mathExpression", tokens);
-                var comparisonOp, initialComparisonOp = null;
-                comparisonOp = tokens.matchAnyOpToken("<", ">", "<=", ">=", "==", "===")
-                while (comparisonOp) {
-                    initialComparisonOp = initialComparisonOp || comparisonOp;
-                    if(initialComparisonOp.value !== comparisonOp.value) {
-                        parser.raiseParseError(tokens, "You must parenthesize comparison operations with different operators")
-                    }
-                    var rhs = parser.parseElement("mathExpression", tokens);
-                    expr = {
-                        type: "comparisonOperator",
-                        operator: comparisonOp.value,
-                        lhs: expr,
-                        rhs: rhs,
-                        transpile: function () {
-                            return parser.transpile(this.lhs) + " " + this.operator + " " + parser.transpile(this.rhs);
-                        }
-                    }
-                    comparisonOp = tokens.matchAnyOpToken("<", ">", "<=", ">=", "==", "===")
-                }
-                return expr;
-            });
-
-            _parser.addGrammarElement("comparisonExpression", function (parser, tokens) {
-                return parser.parseAnyOf(["comparisonOperator", "mathExpression"], tokens);
-            });
-
-            _parser.addGrammarElement("logicalOperator", function (parser, tokens) {
-                var expr = parser.parseElement("comparisonExpression", tokens);
-                var logicalOp, initialLogicalOp = null;
-                logicalOp = tokens.matchToken("and") || tokens.matchToken("or");
-                while (logicalOp) {
-                    initialLogicalOp = initialLogicalOp || logicalOp;
-                    if(initialLogicalOp.value !== logicalOp.value) {
-                        parser.raiseParseError(tokens, "You must parenthesize logical operations with different operators")
-                    }
-                    var rhs = parser.parseElement("comparisonExpression", tokens);
-                    expr = {
-                        type: "logicalOperator",
-                        operator: logicalOp.value,
-                        lhs: expr,
-                        rhs: rhs,
-                        transpile: function () {
-                            return parser.transpile(this.lhs) + " " + (this.operator === "and" ? " && " : " || ") + " " + parser.transpile(this.rhs);
-                        }
-                    }
-                    logicalOp = tokens.matchToken("and") || tokens.matchToken("or");
-                }
-                return expr;
-            });
-
-            _parser.addGrammarElement("logicalExpression", function (parser, tokens) {
-                return parser.parseAnyOf(["logicalOperator", "mathExpression"], tokens);
-            });
-
-            _parser.addGrammarElement("expression", function (parser, tokens) {
-                return parser.parseElement("logicalExpression", tokens);
-            });
-
-            _parser.addGrammarElement("target", function (parser, tokens) {
-                var root = parser.parseAnyOf(["symbol", "classRef", "idRef"], tokens);
-                if (root == null) {
-                    parser.raiseParseError(tokens, "Expected a valid target expression");
-                }
-
-                var propPath = []
-                while (tokens.matchOpToken(".")) {
-                    propPath.push(tokens.requireTokenType("IDENTIFIER").value)
-                }
-
                 return {
-                    type: "target",
-                    propPath: propPath,
+                    type: "objectLiteral",
+                    fields: fields,
+                    transpile: function () {
+                        return "({" + fields.map(function (field) {
+                            return field.name.value + ":" + parser.transpile(field.value);
+                        }).join(", ") + "})";
+                    }
+                };
+            }
+        });
+        _parser.addGrammarElement("namedArgumentList", function (parser, tokens) {
+            if (tokens.matchOpToken("(")) {
+                var fields = [];
+                if (!tokens.matchOpToken(")")) {
+                    do {
+                        var name = tokens.requireTokenType("IDENTIFIER");
+                        tokens.requireOpToken(":");
+                        var value = parser.parseElement("expression", tokens);
+                        fields.push({ name: name, value: value });
+                    } while (tokens.matchOpToken(","));
+                    tokens.requireOpToken(")");
+                }
+                return {
+                    type: "namedArgumentList",
+                    fields: fields,
+                    transpile: function () {
+                        return "({_namedArgList_:true, " + fields.map(function (field) {
+                            return field.name.value + ":" + parser.transpile(field.value);
+                        }).join(", ") + "})";
+                    }
+                };
+            }
+        });
+        _parser.addGrammarElement("symbol", function (parser, tokens) {
+            var identifier = tokens.matchTokenType('IDENTIFIER');
+            if (identifier) {
+                return {
+                    type: "symbol",
+                    name: identifier.value,
+                    transpile: function () {
+                        return identifier.value;
+                    }
+                };
+            }
+        });
+        _parser.addGrammarElement("implicitMeTarget", function (parser, tokens) {
+            return {
+                type: "implicitMeTarget",
+                transpile: function () {
+                    return "[me]";
+                }
+            };
+        });
+        _parser.addGrammarElement("implicitAllTarget", function (parser, tokens) {
+            return {
+                type: "implicitAllTarget",
+                transpile: function () {
+                    return 'document.querySelectorAll("*")';
+                }
+            };
+        });
+        _parser.addGrammarElement("millisecondLiteral", function (parser, tokens) {
+            var number = tokens.requireTokenType(tokens, "NUMBER");
+            var factor = 1;
+            if (tokens.matchToken("s")) {
+                factor = 1000;
+            }
+            else if (tokens.matchToken("ms")) {
+                // do nothing
+            }
+            return {
+                type: "millisecondLiteral",
+                number: number,
+                factor: factor,
+                transpile: function () {
+                    return factor * parseFloat(this.number.value);
+                }
+            };
+        });
+        _parser.addGrammarElement("boolean", function (parser, tokens) {
+            var booleanLiteral = tokens.matchToken("true") || tokens.matchToken("false");
+            if (booleanLiteral) {
+                return {
+                    type: "boolean",
+                    transpile: function () {
+                        return booleanLiteral.value;
+                    }
+                };
+            }
+        });
+        _parser.addGrammarElement("null", function (parser, tokens) {
+            if (tokens.matchToken('null')) {
+                return {
+                    type: "null",
+                    transpile: function () {
+                        return "null";
+                    }
+                };
+            }
+        });
+        _parser.addGrammarElement("arrayLiteral", function (parser, tokens) {
+            if (tokens.matchOpToken('[')) {
+                var values = [];
+                if (!tokens.matchOpToken(']')) {
+                    do {
+                        var expr = parser.parseElement("expression", tokens);
+                        if (expr == null) {
+                            parser.raiseParseError(tokens, "Expected an expression");
+                        }
+                        values.push(expr);
+                    } while (tokens.matchOpToken(","));
+                    tokens.requireOpToken("]");
+                }
+                return {
+                    type: "arrayLiteral",
+                    values: values,
+                    transpile: function () {
+                        return "[" + values.map(function (v) { return parser.transpile(v); }).join(", ") + "]";
+                    }
+                };
+            }
+        });
+        _parser.addGrammarElement("blockLiteral", function (parser, tokens) {
+            if (tokens.matchOpToken('\\')) {
+                var args = [];
+                var arg1 = tokens.matchTokenType("IDENTIFIER");
+                if (arg1) {
+                    args.push(arg1);
+                    while (tokens.matchOpToken(",")) {
+                        args.push(tokens.requireTokenType("IDENTIFIER"));
+                    }
+                }
+                // TODO compound op token
+                tokens.requireOpToken("-");
+                tokens.requireOpToken(">");
+                var expr = parser.parseElement("expression", tokens);
+                if (expr == null) {
+                    parser.raiseParseError(tokens, "Expected an expression");
+                }
+                return {
+                    type: "blockLiteral",
+                    args: args,
+                    expr: expr,
+                    transpile: function () {
+                        return "function(" + args.map(function (arg) {
+                            return arg.value;
+                        }).join(", ") + "){ return " +
+                            parser.transpile(expr) + " }";
+                    }
+                };
+            }
+        });
+        _parser.addGrammarElement("leaf", function (parser, tokens) {
+            return parser.parseAnyOf(["parenthesized", "boolean", "null", "string", "number", "idRef", "classRef", "symbol", "propertyRef", "objectLiteral", "arrayLiteral", "blockLiteral"], tokens);
+        });
+        _parser.addGrammarElement("propertyAccess", function (parser, tokens, root) {
+            if (tokens.matchOpToken(".")) {
+                var prop = tokens.requireTokenType("IDENTIFIER");
+                var propertyAccess = {
+                    type: "propertyAccess",
+                    root: root,
+                    prop: prop,
+                    transpile: function () {
+                        return parser.transpile(root) + "." + prop.value;
+                    }
+                };
+                return _parser.parseElement("indirectExpression", tokens, propertyAccess);
+            }
+        });
+        _parser.addGrammarElement("functionCall", function (parser, tokens, root) {
+            if (tokens.matchOpToken("(")) {
+                var args = [];
+                do {
+                    args.push(parser.parseElement("expression", tokens));
+                } while (tokens.matchOpToken(","));
+                tokens.requireOpToken(")");
+                var functionCall = {
+                    type: "functionCall",
+                    root: root,
+                    args: args,
+                    transpile: function () {
+                        return parser.transpile(root) + "(" + args.map(function (arg) {
+                            return parser.transpile(arg);
+                        }).join(",") + ")";
+                    }
+                };
+                return _parser.parseElement("indirectExpression", tokens, functionCall);
+            }
+        });
+        _parser.addGrammarElement("indirectExpression", function (parser, tokens, root) {
+            var propAccess = parser.parseElement("propertyAccess", tokens, root);
+            if (propAccess) {
+                return propAccess;
+            }
+            var functionCall = parser.parseElement("functionCall", tokens, root);
+            if (functionCall) {
+                return functionCall;
+            }
+            return root;
+        });
+        _parser.addGrammarElement("primaryExpression", function (parser, tokens) {
+            var leaf = parser.parseElement("leaf", tokens);
+            if (leaf) {
+                return parser.parseElement("indirectExpression", tokens, leaf);
+            }
+            parser.raiseParseError(tokens, "Unexpected value: " + tokens.currentToken().value);
+        });
+        _parser.addGrammarElement("postfixExpression", function (parser, tokens) {
+            var root = parser.parseElement("primaryExpression", tokens);
+            if (tokens.matchOpToken(":")) {
+                var typeName = tokens.requireTokenType("IDENTIFIER");
+                var nullOk = !tokens.matchOpToken("!");
+                return {
+                    type: "typeCheck",
+                    typeName: typeName,
+                    root: root,
+                    nullOk: nullOk,
+                    transpile: function () {
+                        return "_hyperscript.runtime.typeCheck(" + parser.transpile(root) + ", '" + typeName.value + "', " + nullOk + ")";
+                    }
+                };
+            }
+            else {
+                return root;
+            }
+        });
+        _parser.addGrammarElement("logicalNot", function (parser, tokens) {
+            if (tokens.matchToken("not")) {
+                var root = parser.parseElement("unaryExpression", tokens);
+                return {
+                    type: "logicalNot",
                     root: root,
                     transpile: function () {
-                        return "_hyperscript.runtime.evalTarget(" + parser.transpile(root) + ", [" + propPath.map(function (prop) {
-                            return "\"" + prop + "\""
-                        }).join(", ") + "])";
+                        return "!" + parser.transpile(root);
                     }
                 };
-            });
-
-            _parser.addGrammarElement("command", function (parser, tokens) {
-                return parser.parseAnyOf(["onCmd", "addCmd", "removeCmd", "toggleCmd", "waitCmd", "sendCmd", "triggerCmd",
-                    "takeCmd", "logCmd", "callCmd", "putCmd", "setCmd", "ifCmd", "ajaxCmd"], tokens);
-            })
-
-            _parser.addGrammarElement("commandList", function (parser, tokens) {
-                var cmd = parser.parseElement("command", tokens);
-                if (cmd) {
-                    tokens.matchToken("then");
-                    cmd.next = parser.parseElement("commandList", tokens);
-                    return cmd;
+            }
+        });
+        _parser.addGrammarElement("negativeNumber", function (parser, tokens) {
+            if (tokens.matchOpToken("-")) {
+                var root = parser.parseElement("unaryExpression", tokens);
+                return {
+                    type: "negativeNumber",
+                    root: root,
+                    transpile: function () {
+                        return "-" + parser.transpile(root);
+                    }
+                };
+            }
+        });
+        _parser.addGrammarElement("unaryExpression", function (parser, tokens) {
+            return parser.parseAnyOf(["logicalNot", "negativeNumber", "postfixExpression"], tokens);
+        });
+        _parser.addGrammarElement("mathOperator", function (parser, tokens) {
+            var expr = parser.parseElement("unaryExpression", tokens);
+            var mathOp, initialMathOp = null;
+            mathOp = tokens.matchAnyOpToken("+", "-", "*", "/", "%");
+            while (mathOp) {
+                initialMathOp = initialMathOp || mathOp;
+                if (initialMathOp.value !== mathOp.value) {
+                    parser.raiseParseError(tokens, "You must parenthesize math operations with different operators");
                 }
-            })
-
-            _parser.addGrammarElement("hyperscript", function (parser, tokens) {
-                var eventListeners = []
+                var rhs = parser.parseElement("unaryExpression", tokens);
+                expr = {
+                    type: "mathOperator",
+                    operator: mathOp.value,
+                    lhs: expr,
+                    rhs: rhs,
+                    transpile: function () {
+                        return parser.transpile(this.lhs) + " " + this.operator + " " + parser.transpile(this.rhs);
+                    }
+                };
+                mathOp = tokens.matchAnyOpToken("+", "-", "*", "/", "%");
+            }
+            return expr;
+        });
+        _parser.addGrammarElement("mathExpression", function (parser, tokens) {
+            return parser.parseAnyOf(["mathOperator", "unaryExpression"], tokens);
+        });
+        _parser.addGrammarElement("comparisonOperator", function (parser, tokens) {
+            var expr = parser.parseElement("mathExpression", tokens);
+            var comparisonOp, initialComparisonOp = null;
+            comparisonOp = tokens.matchAnyOpToken("<", ">", "<=", ">=", "==", "===");
+            while (comparisonOp) {
+                initialComparisonOp = initialComparisonOp || comparisonOp;
+                if (initialComparisonOp.value !== comparisonOp.value) {
+                    parser.raiseParseError(tokens, "You must parenthesize comparison operations with different operators");
+                }
+                var rhs = parser.parseElement("mathExpression", tokens);
+                expr = {
+                    type: "comparisonOperator",
+                    operator: comparisonOp.value,
+                    lhs: expr,
+                    rhs: rhs,
+                    transpile: function () {
+                        return parser.transpile(this.lhs) + " " + this.operator + " " + parser.transpile(this.rhs);
+                    }
+                };
+                comparisonOp = tokens.matchAnyOpToken("<", ">", "<=", ">=", "==", "===");
+            }
+            return expr;
+        });
+        _parser.addGrammarElement("comparisonExpression", function (parser, tokens) {
+            return parser.parseAnyOf(["comparisonOperator", "mathExpression"], tokens);
+        });
+        _parser.addGrammarElement("logicalOperator", function (parser, tokens) {
+            var expr = parser.parseElement("comparisonExpression", tokens);
+            var logicalOp, initialLogicalOp = null;
+            logicalOp = tokens.matchToken("and") || tokens.matchToken("or");
+            while (logicalOp) {
+                initialLogicalOp = initialLogicalOp || logicalOp;
+                if (initialLogicalOp.value !== logicalOp.value) {
+                    parser.raiseParseError(tokens, "You must parenthesize logical operations with different operators");
+                }
+                var rhs = parser.parseElement("comparisonExpression", tokens);
+                expr = {
+                    type: "logicalOperator",
+                    operator: logicalOp.value,
+                    lhs: expr,
+                    rhs: rhs,
+                    transpile: function () {
+                        return parser.transpile(this.lhs) + " " + (this.operator === "and" ? " && " : " || ") + " " + parser.transpile(this.rhs);
+                    }
+                };
+                logicalOp = tokens.matchToken("and") || tokens.matchToken("or");
+            }
+            return expr;
+        });
+        _parser.addGrammarElement("logicalExpression", function (parser, tokens) {
+            return parser.parseAnyOf(["logicalOperator", "mathExpression"], tokens);
+        });
+        _parser.addGrammarElement("expression", function (parser, tokens) {
+            return parser.parseElement("logicalExpression", tokens);
+        });
+        _parser.addGrammarElement("target", function (parser, tokens) {
+            var root = parser.parseAnyOf(["symbol", "classRef", "idRef"], tokens);
+            if (root == null) {
+                parser.raiseParseError(tokens, "Expected a valid target expression");
+            }
+            var propPath = [];
+            while (tokens.matchOpToken(".")) {
+                propPath.push(tokens.requireTokenType("IDENTIFIER").value);
+            }
+            return {
+                type: "target",
+                propPath: propPath,
+                root: root,
+                transpile: function () {
+                    return "_hyperscript.runtime.evalTarget(" + parser.transpile(root) + ", [" + propPath.map(function (prop) {
+                        return "\"" + prop + "\"";
+                    }).join(", ") + "])";
+                }
+            };
+        });
+        _parser.addGrammarElement("command", function (parser, tokens) {
+            return parser.parseAnyOf(["onCmd", "addCmd", "removeCmd", "toggleCmd", "waitCmd", "sendCmd", "triggerCmd",
+                "takeCmd", "logCmd", "callCmd", "putCmd", "setCmd", "ifCmd", "ajaxCmd"], tokens);
+        });
+        _parser.addGrammarElement("commandList", function (parser, tokens) {
+            var cmd = parser.parseElement("command", tokens);
+            if (cmd) {
+                tokens.matchToken("then");
+                cmd.next = parser.parseElement("commandList", tokens);
+                return cmd;
+            }
+        });
+        _parser.addGrammarElement("hyperscript", function (parser, tokens) {
+            var eventListeners = [];
+            do {
+                eventListeners.push(parser.parseElement("eventListener", tokens));
+            } while (tokens.matchToken("end") && tokens.hasMore());
+            if (tokens.hasMore()) {
+                parser.raiseParseError(tokens);
+            }
+            return {
+                type: "hyperscript",
+                eventListeners: eventListeners,
+                transpile: function () {
+                    return "(function(){\n" +
+                        "var eventListeners = []\n" +
+                        eventListeners.map(function (el) {
+                            return "  eventListeners.push(" + parser.transpile(el) + ");\n";
+                        }).join("") +
+                        "      function applyEventListenersTo(elt) { _hyperscript.runtime.applyEventListeners(this, elt) }\n" +
+                        "      return {eventListeners:eventListeners, applyEventListenersTo:applyEventListenersTo}\n" +
+                        "})()";
+                }
+            };
+        });
+        _parser.addGrammarElement("eventListener", function (parser, tokens) {
+            tokens.requireToken("on");
+            var on = parser.parseElement("dotPath", tokens);
+            if (on == null) {
+                parser.raiseParseError(tokens, "Expected event name");
+            }
+            if (tokens.matchToken("from")) {
+                var from = parser.parseElement("target", tokens);
+                if (from == null) {
+                    parser.raiseParseError(tokens, "Expected target value");
+                }
+            }
+            else {
+                var from = parser.parseElement("implicitMeTarget", tokens);
+            }
+            var args = [];
+            if (tokens.matchOpToken("(")) {
                 do {
-                    eventListeners.push(parser.parseElement("eventListener", tokens));
-                } while (tokens.matchToken("end") && tokens.hasMore())
-                if (tokens.hasMore()) {
-                    parser.raiseParseError(tokens);
+                    args.push(tokens.requireTokenType('IDENTIFIER'));
+                } while (tokens.matchOpToken(","));
+                tokens.requireOpToken(')');
+            }
+            var start = parser.parseElement("commandList", tokens);
+            var eventListener = {
+                type: "eventListener",
+                on: on,
+                from: from,
+                start: start,
+                transpile: function () {
+                    return "(function(me){" +
+                        "var my = me;\n" +
+                        "_hyperscript.runtime.forEach( " + parser.transpile(from) + ", function(target){\n" +
+                        "  target.addEventListener('" + parser.transpile(on) + "', function(event){\n" +
+                        args.map(function (arg) { return "var " + arg.value + " = event.detail." + arg.value + ";"; }).join("\n") + "\n" +
+                        parser.transpile(start) +
+                        "  })\n" +
+                        "})\n" +
+                        "})";
+                }
+            };
+            return eventListener;
+        });
+        _parser.addGrammarElement("addCmd", function (parser, tokens) {
+            if (tokens.matchToken("add")) {
+                var classRef = parser.parseElement("classRef", tokens);
+                var attributeRef = null;
+                if (classRef == null) {
+                    attributeRef = parser.parseElement("attributeRef", tokens);
+                    if (attributeRef == null) {
+                        parser.raiseParseError(tokens, "Expected either a class reference or attribute expression");
+                    }
+                }
+                if (tokens.matchToken("to")) {
+                    var to = parser.parseElement("target", tokens);
+                }
+                else {
+                    var to = parser.parseElement("implicitMeTarget");
                 }
                 return {
-                    type: "hyperscript",
-                    eventListeners: eventListeners,
+                    type: "addCmd",
+                    classRef: classRef,
+                    attributeRef: attributeRef,
+                    to: to,
                     transpile: function () {
-                        return "(function(){\n" +
-                            "var eventListeners = []\n" +
-                            eventListeners.map(function (el) {
-                                return "  eventListeners.push(" + parser.transpile(el) + ");\n"
-                            }).join("") +
-                            "      function applyEventListenersTo(elt) { _hyperscript.runtime.applyEventListeners(this, elt) }\n" +
-                            "      return {eventListeners:eventListeners, applyEventListenersTo:applyEventListenersTo}\n" +
-                            "})()"
+                        if (this.classRef) {
+                            return "_hyperscript.runtime.forEach( " + parser.transpile(to) + ", function (target) {" +
+                                "  target.classList.add('" + classRef.className() + "')" +
+                                "})";
+                        }
+                        else {
+                            return "_hyperscript.runtime.forEach( " + parser.transpile(to) + ", function (target) {" +
+                                "  target.setAttribute('" + attributeRef.name + "', " + parser.transpile(attributeRef) + ".value)" +
+                                "})";
+                        }
                     }
                 };
-            })
-
-
-            _parser.addGrammarElement("eventListener", function (parser, tokens) {
-                tokens.requireToken("on");
-                var on = parser.parseElement("dotPath", tokens);
-                if (on == null) {
-                    parser.raiseParseError(tokens, "Expected event name")
+            }
+        });
+        _parser.addGrammarElement("removeCmd", function (parser, tokens) {
+            if (tokens.matchToken("remove")) {
+                var classRef = parser.parseElement("classRef", tokens);
+                var attributeRef = null;
+                var elementExpr = null;
+                if (classRef == null) {
+                    attributeRef = parser.parseElement("attributeRef", tokens);
+                    if (attributeRef == null) {
+                        elementExpr = parser.parseElement("expression", tokens);
+                        if (elementExpr == null) {
+                            parser.raiseParseError(tokens, "Expected either a class reference, attribute expression or value expression");
+                        }
+                    }
                 }
                 if (tokens.matchToken("from")) {
                     var from = parser.parseElement("target", tokens);
-                    if (from == null) {
-                        parser.raiseParseError(tokens, "Expected target value")
-                    }
-                } else {
-                    var from = parser.parseElement("implicitMeTarget", tokens);
                 }
-
-                var args = [];
-                if (tokens.matchOpToken("(")) {
-                    do {
-                        args.push(tokens.requireTokenType('IDENTIFIER'));
-                    } while (tokens.matchOpToken(","))
-                    tokens.requireOpToken(')')
+                else {
+                    var from = parser.parseElement("implicitMeTarget");
                 }
-
-                var start = parser.parseElement("commandList", tokens);
-                var eventListener = {
-                    type: "eventListener",
-                    on: on,
+                return {
+                    type: "removeCmd",
+                    classRef: classRef,
+                    attributeRef: attributeRef,
+                    elementExpr: elementExpr,
                     from: from,
-                    start: start,
                     transpile: function () {
-                        return "(function(me){" +
-                            "var my = me;\n" +
-                            "_hyperscript.runtime.forEach( " + parser.transpile(from) + ", function(target){\n" +
-                            "  target.addEventListener('" + parser.transpile(on) + "', function(event){\n" +
-                            args.map(function(arg){return "var " + arg.value + " = event.detail." + arg.value + ";"}).join("\n") + "\n" +
-                            parser.transpile(start) +
-                            "  })\n" +
-                            "})\n" +
-                            "})"
+                        if (this.elementExpr) {
+                            return "_hyperscript.runtime.forEach( " + parser.transpile(elementExpr) + ", function (target) {" +
+                                "  target.parentElement.removeChild(target)" +
+                                "})";
+                        }
+                        else {
+                            if (this.classRef) {
+                                return "_hyperscript.runtime.forEach( " + parser.transpile(from) + ", function (target) {" +
+                                    "  target.classList.remove('" + classRef.className() + "')" +
+                                    "})";
+                            }
+                            else {
+                                return "_hyperscript.runtime.forEach( " + parser.transpile(from) + ", function (target) {" +
+                                    "  target.removeAttribute('" + attributeRef.name + "')" +
+                                    "})";
+                            }
+                        }
                     }
                 };
-                return eventListener;
-            });
-
-            _parser.addGrammarElement("addCmd", function (parser, tokens) {
-                if (tokens.matchToken("add")) {
-                    var classRef = parser.parseElement("classRef", tokens);
-                    var attributeRef = null;
-                    if (classRef == null) {
-                        attributeRef = parser.parseElement("attributeRef", tokens);
-                        if (attributeRef == null) {
-                            parser.raiseParseError(tokens, "Expected either a class reference or attribute expression")
-                        }
-                    }
-
-                    if (tokens.matchToken("to")) {
-                        var to = parser.parseElement("target", tokens);
-                    } else {
-                        var to = parser.parseElement("implicitMeTarget");
-                    }
-
-                    return {
-                        type: "addCmd",
-                        classRef: classRef,
-                        attributeRef: attributeRef,
-                        to: to,
-                        transpile: function () {
-                            if (this.classRef) {
-                                return "_hyperscript.runtime.forEach( " + parser.transpile(to) + ", function (target) {" +
-                                    "  target.classList.add('" + classRef.className() + "')" +
-                                    "})";
-                            } else {
-                                return "_hyperscript.runtime.forEach( " + parser.transpile(to) + ", function (target) {" +
-                                    "  target.setAttribute('" + attributeRef.name + "', " + parser.transpile(attributeRef) + ".value)" +
-                                    "})";
-                            }
-                        }
+            }
+        });
+        _parser.addGrammarElement("toggleCmd", function (parser, tokens) {
+            if (tokens.matchToken("toggle")) {
+                var classRef = parser.parseElement("classRef", tokens);
+                var attributeRef = null;
+                if (classRef == null) {
+                    attributeRef = parser.parseElement("attributeRef", tokens);
+                    if (attributeRef == null) {
+                        parser.raiseParseError(tokens, "Expected either a class reference or attribute expression");
                     }
                 }
-            });
-
-            _parser.addGrammarElement("removeCmd", function (parser, tokens) {
-                if (tokens.matchToken("remove")) {
-                    var classRef = parser.parseElement("classRef", tokens);
-                    var attributeRef = null;
-                    var elementExpr = null;
-                    if (classRef == null) {
-                        attributeRef = parser.parseElement("attributeRef", tokens);
-                        if (attributeRef == null) {
-                            elementExpr = parser.parseElement("expression", tokens)
-                            if (elementExpr == null) {
-                                parser.raiseParseError(tokens, "Expected either a class reference, attribute expression or value expression");
-                            }
-                        }
-                    }
-                    if (tokens.matchToken("from")) {
-                        var from = parser.parseElement("target", tokens);
-                    } else {
-                        var from = parser.parseElement("implicitMeTarget");
-                    }
-
-                    return {
-                        type: "removeCmd",
-                        classRef: classRef,
-                        attributeRef: attributeRef,
-                        elementExpr: elementExpr,
-                        from: from,
-                        transpile: function () {
-                            if (this.elementExpr) {
-                                return "_hyperscript.runtime.forEach( " + parser.transpile(elementExpr) + ", function (target) {" +
-                                    "  target.parentElement.removeChild(target)" +
-                                    "})";
-                            } else {
-                                if (this.classRef) {
-                                    return "_hyperscript.runtime.forEach( " + parser.transpile(from) + ", function (target) {" +
-                                        "  target.classList.remove('" + classRef.className() + "')" +
-                                        "})";
-                                } else {
-                                    return "_hyperscript.runtime.forEach( " + parser.transpile(from) + ", function (target) {" +
-                                        "  target.removeAttribute('" + attributeRef.name + "')" +
-                                        "})";
-                                }
-                            }
-                        }
-                    }
+                if (tokens.matchToken("on")) {
+                    var on = parser.parseElement("target", tokens);
                 }
-            });
-
-            _parser.addGrammarElement("toggleCmd", function (parser, tokens) {
-                if (tokens.matchToken("toggle")) {
-                    var classRef = parser.parseElement("classRef", tokens);
-                    var attributeRef = null;
-                    if (classRef == null) {
-                        attributeRef = parser.parseElement("attributeRef", tokens);
-                        if (attributeRef == null) {
-                            parser.raiseParseError(tokens, "Expected either a class reference or attribute expression")
-                        }
-                    }
-                    if (tokens.matchToken("on")) {
-                        var on = parser.parseElement("target", tokens);
-                    } else {
-                        var on = parser.parseElement("implicitMeTarget");
-                    }
-                    return {
-                        type: "toggleCmd",
-                        classRef: classRef,
-                        attributeRef: attributeRef,
-                        on: on,
-                        transpile: function () {
-                            if (this.classRef) {
-                                return "_hyperscript.runtime.forEach( " + parser.transpile(on) + ", function (target) {" +
-                                    "  target.classList.toggle('" + classRef.className() + "')" +
-                                    "})";
-                            } else {
-                                return "_hyperscript.runtime.forEach( " + parser.transpile(on) + ", function (target) {" +
-                                    "  if(target.hasAttribute('" + attributeRef.name + "')) {\n" +
-                                    "    target.removeAttribute('" + attributeRef.name + "');\n" +
-                                    "  } else { \n" +
-                                    "    target.setAttribute('" + attributeRef.name + "', " + parser.transpile(attributeRef) + ".value)" +
-                                    "  }" +
-                                    "})";
-                            }
-                        }
-                    }
+                else {
+                    var on = parser.parseElement("implicitMeTarget");
                 }
-            })
-
-            _parser.addGrammarElement("waitCmd", function (parser, tokens) {
-                if (tokens.matchToken("wait")) {
-                    var time = parser.parseElement('millisecondLiteral', tokens);
-                    return {
-                        type: "waitCmd",
-                        time: time,
-                        transpile: function () {
-                            var capturedNext = this.next;
-                            delete this.next;
-                            return "setTimeout(function () { " + parser.transpile(capturedNext) + " }, " + parser.transpile(this.time) + ")";
+                return {
+                    type: "toggleCmd",
+                    classRef: classRef,
+                    attributeRef: attributeRef,
+                    on: on,
+                    transpile: function () {
+                        if (this.classRef) {
+                            return "_hyperscript.runtime.forEach( " + parser.transpile(on) + ", function (target) {" +
+                                "  target.classList.toggle('" + classRef.className() + "')" +
+                                "})";
                         }
-                    }
-                }
-            })
-
-            _parser.addGrammarElement("dotPath", function (parser, tokens) {
-                var root = tokens.matchTokenType("IDENTIFIER");
-                if (root) {
-                    var path = [root.value];
-                    while (tokens.matchOpToken(".")) {
-                        path.push(tokens.requireTokenType("IDENTIFIER").value);
-                    }
-                    return {
-                        type: "dotPath",
-                        path: path,
-                        transpile: function () {
-                            return path.join(".");
-                        }
-                    }
-                }
-            });
-
-            _parser.addGrammarElement("sendCmd", function (parser, tokens) {
-                if (tokens.matchToken("send")) {
-
-                    var eventName = parser.parseElement("dotPath", tokens);
-
-                    var details = parser.parseElement("namedArgumentList", tokens);
-                    if (tokens.matchToken("to")) {
-                        var to = parser.parseElement("target", tokens);
-                    } else {
-                        var to = parser.parseElement("implicitMeTarget");
-                    }
-
-                    return {
-                        type: "sendCmd",
-                        eventName: eventName,
-                        details: details,
-                        to: to,
-                        transpile: function () {
-                            return "_hyperscript.runtime.forEach( " + parser.transpile(to) + ", function (target) {" +
-                                "  _hyperscript.runtime.triggerEvent(target, '" + parser.transpile(eventName) + "'," + parser.transpile(details, "{}") + ")" +
+                        else {
+                            return "_hyperscript.runtime.forEach( " + parser.transpile(on) + ", function (target) {" +
+                                "  if(target.hasAttribute('" + attributeRef.name + "')) {\n" +
+                                "    target.removeAttribute('" + attributeRef.name + "');\n" +
+                                "  } else { \n" +
+                                "    target.setAttribute('" + attributeRef.name + "', " + parser.transpile(attributeRef) + ".value)" +
+                                "  }" +
                                 "})";
                         }
                     }
+                };
+            }
+        });
+        _parser.addGrammarElement("waitCmd", function (parser, tokens) {
+            if (tokens.matchToken("wait")) {
+                var time = parser.parseElement('millisecondLiteral', tokens);
+                return {
+                    type: "waitCmd",
+                    time: time,
+                    transpile: function () {
+                        var capturedNext = this.next;
+                        delete this.next;
+                        return "setTimeout(function () { " + parser.transpile(capturedNext) + " }, " + parser.transpile(this.time) + ")";
+                    }
+                };
+            }
+        });
+        _parser.addGrammarElement("dotPath", function (parser, tokens) {
+            var root = tokens.matchTokenType("IDENTIFIER");
+            if (root) {
+                var path = [root.value];
+                while (tokens.matchOpToken(".")) {
+                    path.push(tokens.requireTokenType("IDENTIFIER").value);
                 }
-            })
-
-            _parser.addGrammarElement("triggerCmd", function (parser, tokens) {
-                if (tokens.matchToken("trigger")) {
-
-                    var eventName = parser.parseElement("dotPath", tokens);
-                    var details = parser.parseElement("namedArgumentList", tokens);
-
-                    return {
-                        type: "triggerCmd",
-                        eventName: eventName,
-                        details: details,
-                        transpile: function () {
-                            return "_hyperscript.runtime.triggerEvent(me, '" + parser.transpile(eventName) + "'," + parser.transpile(details, "{}") + ");";
+                return {
+                    type: "dotPath",
+                    path: path,
+                    transpile: function () {
+                        return path.join(".");
+                    }
+                };
+            }
+        });
+        _parser.addGrammarElement("sendCmd", function (parser, tokens) {
+            if (tokens.matchToken("send")) {
+                var eventName = parser.parseElement("dotPath", tokens);
+                var details = parser.parseElement("namedArgumentList", tokens);
+                if (tokens.matchToken("to")) {
+                    var to = parser.parseElement("target", tokens);
+                }
+                else {
+                    var to = parser.parseElement("implicitMeTarget");
+                }
+                return {
+                    type: "sendCmd",
+                    eventName: eventName,
+                    details: details,
+                    to: to,
+                    transpile: function () {
+                        return "_hyperscript.runtime.forEach( " + parser.transpile(to) + ", function (target) {" +
+                            "  _hyperscript.runtime.triggerEvent(target, '" + parser.transpile(eventName) + "'," + parser.transpile(details, "{}") + ")" +
+                            "})";
+                    }
+                };
+            }
+        });
+        _parser.addGrammarElement("triggerCmd", function (parser, tokens) {
+            if (tokens.matchToken("trigger")) {
+                var eventName = parser.parseElement("dotPath", tokens);
+                var details = parser.parseElement("namedArgumentList", tokens);
+                return {
+                    type: "triggerCmd",
+                    eventName: eventName,
+                    details: details,
+                    transpile: function () {
+                        return "_hyperscript.runtime.triggerEvent(me, '" + parser.transpile(eventName) + "'," + parser.transpile(details, "{}") + ");";
+                    }
+                };
+            }
+        });
+        _parser.addGrammarElement("takeCmd", function (parser, tokens) {
+            if (tokens.matchToken("take")) {
+                var classRef = tokens.requireTokenType(tokens, "CLASS_REF");
+                if (tokens.matchToken("from")) {
+                    var from = parser.parseElement("target", tokens);
+                }
+                else {
+                    var from = parser.parseElement("implicitAllTarget");
+                }
+                if (tokens.matchToken("for")) {
+                    var forElt = parser.parseElement("target", tokens);
+                }
+                else {
+                    var forElt = parser.parseElement("implicitMeTarget");
+                }
+                return {
+                    type: "takeCmd",
+                    classRef: classRef,
+                    from: from,
+                    forElt: forElt,
+                    transpile: function () {
+                        var clazz = this.classRef.value.substr(1);
+                        return "  _hyperscript.runtime.forEach(" + parser.transpile(from) + ", function (target) { target.classList.remove('" + clazz + "') }); " +
+                            "_hyperscript.runtime.forEach( " + parser.transpile(forElt) + ", function (target) {" +
+                            "  target.classList.add('" + clazz + "')" +
+                            "})";
+                    }
+                };
+            }
+        });
+        _parser.addGrammarElement("logCmd", function (parser, tokens) {
+            if (tokens.matchToken("log")) {
+                var exprs = [parser.parseElement("expression", tokens)];
+                while (tokens.matchOpToken(",")) {
+                    exprs.push(parser.parseElement("expression", tokens));
+                }
+                if (tokens.matchToken("with")) {
+                    var withExpr = parser.parseElement("expression", tokens);
+                }
+                return {
+                    type: "logCmd",
+                    exprs: exprs,
+                    withExpr: withExpr,
+                    transpile: function () {
+                        if (withExpr) {
+                            return parser.transpile(withExpr) + "(" + exprs.map(function (expr) {
+                                return parser.transpile(expr);
+                            }).join(", ") + ")";
+                        }
+                        else {
+                            return "console.log(" + exprs.map(function (expr) {
+                                return parser.transpile(expr);
+                            }).join(", ") + ")";
                         }
                     }
+                };
+            }
+        });
+        _parser.addGrammarElement("callCmd", function (parser, tokens) {
+            if (tokens.matchToken("call") || tokens.matchToken("get")) {
+                return {
+                    type: "callCmd",
+                    expr: parser.parseElement("expression", tokens),
+                    transpile: function () {
+                        return "var it = " + parser.transpile(this.expr);
+                    }
+                };
+            }
+        });
+        _parser.addGrammarElement("putCmd", function (parser, tokens) {
+            if (tokens.matchToken("put")) {
+                var value = parser.parseElement("expression", tokens);
+                var operation = tokens.matchToken("into") ||
+                    tokens.matchToken("before") ||
+                    tokens.matchToken("after");
+                if (operation == null && tokens.matchToken("at")) {
+                    operation = tokens.matchToken("start") ||
+                        tokens.matchToken("end");
+                    tokens.requireToken("of");
                 }
-            })
-
-            _parser.addGrammarElement("takeCmd", function (parser, tokens) {
-                if (tokens.matchToken("take")) {
-                    var classRef = tokens.requireTokenType(tokens, "CLASS_REF");
-
-                    if (tokens.matchToken("from")) {
-                        var from = parser.parseElement("target", tokens);
-                    } else {
-                        var from = parser.parseElement("implicitAllTarget")
-                    }
-
-                    if (tokens.matchToken("for")) {
-                        var forElt = parser.parseElement("target", tokens);
-                    } else {
-                        var forElt = parser.parseElement("implicitMeTarget")
-                    }
-
-                    return {
-                        type: "takeCmd",
-                        classRef: classRef,
-                        from: from,
-                        forElt: forElt,
-                        transpile: function () {
-                            var clazz = this.classRef.value.substr(1);
-                            return "  _hyperscript.runtime.forEach(" + parser.transpile(from) + ", function (target) { target.classList.remove('" + clazz + "') }); " +
-                                "_hyperscript.runtime.forEach( " + parser.transpile(forElt) + ", function (target) {" +
-                                "  target.classList.add('" + clazz + "')" +
-                                "})";
+                if (operation == null) {
+                    parser.raiseParseError(tokens, "Expected one of 'into', 'before', 'at start of', 'at end of', 'after'");
+                }
+                var target = parser.parseElement("target", tokens);
+                var directWrite = target.propPath.length === 0 && operation.value === "into";
+                var symbolWrite = directWrite && target.root.type === "symbol";
+                if (directWrite && !symbolWrite) {
+                    parser.raiseParseError(tokens, "Can only put directly into symbols, not references");
+                }
+                return {
+                    type: "putCmd",
+                    target: target,
+                    op: operation.value,
+                    symbolWrite: symbolWrite,
+                    value: value,
+                    transpile: function () {
+                        if (this.symbolWrite) {
+                            return "var " + target.root.name + " = " + parser.transpile(value);
                         }
-                    }
-                }
-            })
-
-            _parser.addGrammarElement("logCmd", function (parser, tokens) {
-                if (tokens.matchToken("log")) {
-                    var exprs = [parser.parseElement("expression", tokens)];
-                    while (tokens.matchOpToken(",")) {
-                        exprs.push(parser.parseElement("expression", tokens));
-                    }
-                    if (tokens.matchToken("with")) {
-                        var withExpr = parser.parseElement("expression", tokens);
-                    }
-                    return {
-                        type: "logCmd",
-                        exprs: exprs,
-                        withExpr: withExpr,
-                        transpile: function () {
-                            if (withExpr) {
-                                return parser.transpile(withExpr) + "(" + exprs.map(function (expr) {
-                                    return parser.transpile(expr)
-                                }).join(", ") + ")";
-                            } else {
-                                return "console.log(" + exprs.map(function (expr) {
-                                    return parser.transpile(expr)
-                                }).join(", ") + ")";
-                            }
-                        }
-                    };
-                }
-            })
-
-            _parser.addGrammarElement("callCmd", function (parser, tokens) {
-                if (tokens.matchToken("call") || tokens.matchToken("get")) {
-                    return {
-                        type: "callCmd",
-                        expr: parser.parseElement("expression", tokens),
-                        transpile: function () {
-                            return "var it = " + parser.transpile(this.expr);
-                        }
-                    }
-                }
-            })
-
-            _parser.addGrammarElement("putCmd", function (parser, tokens) {
-                if (tokens.matchToken("put")) {
-
-                    var value = parser.parseElement("expression", tokens);
-
-                    var operation = tokens.matchToken("into") ||
-                        tokens.matchToken("before") ||
-                        tokens.matchToken("after");
-
-                    if (operation == null && tokens.matchToken("at")) {
-                        operation = tokens.matchToken("start") ||
-                            tokens.matchToken("end");
-                        tokens.requireToken("of");
-                    }
-
-                    if (operation == null) {
-                        parser.raiseParseError(tokens, "Expected one of 'into', 'before', 'at start of', 'at end of', 'after'");
-                    }
-                    var target = parser.parseElement("target", tokens);
-
-                    var directWrite = target.propPath.length === 0 && operation.value === "into";
-                    var symbolWrite = directWrite && target.root.type === "symbol";
-                    if (directWrite && !symbolWrite) {
-                        parser.raiseParseError(tokens, "Can only put directly into symbols, not references")
-                    }
-
-                    return {
-                        type: "putCmd",
-                        target: target,
-                        op: operation.value,
-                        symbolWrite: symbolWrite,
-                        value: value,
-                        transpile: function () {
-                            if (this.symbolWrite) {
-                                return "var " + target.root.name + " = " + parser.transpile(value);
-                            } else {
-                                if (this.op === "into") {
-                                    var lastProperty = target.propPath.pop(); // steal last property for assignment
-                                    return "_hyperscript.runtime.forEach( " + parser.transpile(target) + ", function (target) {" +
-                                        "  target." + lastProperty + "=" + parser.transpile(value) +
-                                        "})";
-                                } else if (this.op === "before") {
-                                    return "_hyperscript.runtime.forEach( " + parser.transpile(target) + ", function (target) {" +
-                                        "  target.insertAdjacentHTML('beforebegin', " + parser.transpile(value) + ")" +
-                                        "})";
-                                } else if (this.op === "start") {
-                                    return "_hyperscript.runtime.forEach( " + parser.transpile(target) + ", function (target) {" +
-                                        "  target.insertAdjacentHTML('afterbegin', " + parser.transpile(value) + ")" +
-                                        "})";
-                                } else if (this.op === "end") {
-                                    return "_hyperscript.runtime.forEach( " + parser.transpile(target) + ", function (target) {" +
-                                        "  target.insertAdjacentHTML('beforeend', " + parser.transpile(value) + ")" +
-                                        "})";
-                                } else if (this.op === "after") {
-                                    return "_hyperscript.runtime.forEach( " + parser.transpile(target) + ", function (target) {" +
-                                        "  target.insertAdjacentHTML('afterend', " + parser.transpile(value) + ")" +
-                                        "})";
-                                }
-                            }
-                        }
-                    }
-                }
-            })
-
-            _parser.addGrammarElement("setCmd", function (parser, tokens) {
-                if (tokens.matchToken("set")) {
-
-                    var target = parser.parseElement("target", tokens);
-
-                    tokens.requireToken("to");
-
-                    var value = parser.parseElement("expression", tokens);
-
-                    var directWrite = target.propPath.length === 0;
-                    var symbolWrite = directWrite && target.root.type === "symbol";
-                    if (directWrite && !symbolWrite) {
-                        parser.raiseParseError(tokens, "Can only put directly into symbols, not references")
-                    }
-
-                    return {
-                        type: "setCmd",
-                        target: target,
-                        symbolWrite: symbolWrite,
-                        value: value,
-                        transpile: function () {
-                            if (this.symbolWrite) {
-                                return "var " + target.root.name + " = " + parser.transpile(value);
-                            } else {
+                        else {
+                            if (this.op === "into") {
                                 var lastProperty = target.propPath.pop(); // steal last property for assignment
                                 return "_hyperscript.runtime.forEach( " + parser.transpile(target) + ", function (target) {" +
                                     "  target." + lastProperty + "=" + parser.transpile(value) +
                                     "})";
                             }
+                            else if (this.op === "before") {
+                                return "_hyperscript.runtime.forEach( " + parser.transpile(target) + ", function (target) {" +
+                                    "  target.insertAdjacentHTML('beforebegin', " + parser.transpile(value) + ")" +
+                                    "})";
+                            }
+                            else if (this.op === "start") {
+                                return "_hyperscript.runtime.forEach( " + parser.transpile(target) + ", function (target) {" +
+                                    "  target.insertAdjacentHTML('afterbegin', " + parser.transpile(value) + ")" +
+                                    "})";
+                            }
+                            else if (this.op === "end") {
+                                return "_hyperscript.runtime.forEach( " + parser.transpile(target) + ", function (target) {" +
+                                    "  target.insertAdjacentHTML('beforeend', " + parser.transpile(value) + ")" +
+                                    "})";
+                            }
+                            else if (this.op === "after") {
+                                return "_hyperscript.runtime.forEach( " + parser.transpile(target) + ", function (target) {" +
+                                    "  target.insertAdjacentHTML('afterend', " + parser.transpile(value) + ")" +
+                                    "})";
+                            }
                         }
                     }
-                }
-            })
-
-            _parser.addGrammarElement("ifCmd", function (parser, tokens) {
-                if (tokens.matchToken("if")) {
-                    var expr = parser.parseElement("expression", tokens);
-                    tokens.matchToken("then"); // optional 'then'
-                    var trueBranch = parser.parseElement("commandList", tokens);
-                    if (tokens.matchToken("else")) {
-                        var falseBranch = parser.parseElement("commandList", tokens);
-                    }
-                    if (tokens.hasMore()) {
-                        tokens.requireToken("end");
-                    }
-                    return {
-                        type: "ifCmd",
-                        expr: expr,
-                        trueBranch: trueBranch,
-                        falseBranch: falseBranch,
-                        transpile: function () {
-                            return "if(" + parser.transpile(expr) + "){" + "" + parser.transpile(trueBranch) + "}" +
-                                "   else {" + parser.transpile(falseBranch, "") + "}"
-
-                        }
-                    }
-                }
-            })
-
-            _parser.addGrammarElement("ajaxCmd", function (parser, tokens) {
-                if (tokens.matchToken("ajax")) {
-                    var method = tokens.matchToken("GET") || tokens.matchToken("POST");
-                    if (method == null) {
-                        parser.raiseParseError(tokens, "Requires either GET or POST");
-                    }
-                    if (method.value !== "GET") {
-                        if (!tokens.matchToken("to")) {
-                            var data = parser.parseElement("expression", tokens);
-                            tokens.requireToken("to");
-                        }
-                    }
-
-                    var url = parser.parseElement("string", tokens);
-                    if (url == null) {
-                        var url = parser.parseElement("nakedString", tokens);
-                    }
-
-                    return {
-                        type: "requestCommand",
-                        method: method,
-                        transpile: function () {
-                            var capturedNext = this.next;
-                            delete this.next;
-                            return "_hyperscript.runtime.ajax('" + method.value + "', " +
-                                parser.transpile(url) + ", " +
-                                "function(response, xhr){ " + parser.transpile(capturedNext) + " }," +
-                                parser.transpile(data, "null") + ")";
-                        }
-                    };
-                }
-            })
-
-            //-----------------------------------------------
-            // API
-            //-----------------------------------------------
-
-            function start(scriptAttrs) {
-                if (scriptAttrs) {
-                    _runtime.setScriptAttrs(scriptAttrs);
-                }
-                var fn = function () {
-                    var elements = document.querySelectorAll(_runtime.getScriptSelector());
-                    _runtime.forEach(elements, function (elt) {
-                        init(elt);
-                    })
                 };
-                if (document.readyState !== 'loading') {
-                    fn();
-                } else {
-                    document.addEventListener('DOMContentLoaded', fn);
+            }
+        });
+        _parser.addGrammarElement("setCmd", function (parser, tokens) {
+            if (tokens.matchToken("set")) {
+                var target = parser.parseElement("target", tokens);
+                tokens.requireToken("to");
+                var value = parser.parseElement("expression", tokens);
+                var directWrite = target.propPath.length === 0;
+                var symbolWrite = directWrite && target.root.type === "symbol";
+                if (directWrite && !symbolWrite) {
+                    parser.raiseParseError(tokens, "Can only put directly into symbols, not references");
                 }
-                return true;
+                return {
+                    type: "setCmd",
+                    target: target,
+                    symbolWrite: symbolWrite,
+                    value: value,
+                    transpile: function () {
+                        if (this.symbolWrite) {
+                            return "var " + target.root.name + " = " + parser.transpile(value);
+                        }
+                        else {
+                            var lastProperty = target.propPath.pop(); // steal last property for assignment
+                            return "_hyperscript.runtime.forEach( " + parser.transpile(target) + ", function (target) {" +
+                                "  target." + lastProperty + "=" + parser.transpile(value) +
+                                "})";
+                        }
+                    }
+                };
             }
-
-            function init(elt) {
-                _runtime.initElement(elt);
+        });
+        _parser.addGrammarElement("ifCmd", function (parser, tokens) {
+            if (tokens.matchToken("if")) {
+                var expr = parser.parseElement("expression", tokens);
+                tokens.matchToken("then"); // optional 'then'
+                var trueBranch = parser.parseElement("commandList", tokens);
+                if (tokens.matchToken("else")) {
+                    var falseBranch = parser.parseElement("commandList", tokens);
+                }
+                if (tokens.hasMore()) {
+                    tokens.requireToken("end");
+                }
+                return {
+                    type: "ifCmd",
+                    expr: expr,
+                    trueBranch: trueBranch,
+                    falseBranch: falseBranch,
+                    transpile: function () {
+                        return "if(" + parser.transpile(expr) + "){" + "" + parser.transpile(trueBranch) + "}" +
+                            "   else {" + parser.transpile(falseBranch, "") + "}";
+                    }
+                };
             }
-
-            function evaluate(str) {
-                return _runtime.evaluate(str);
+        });
+        _parser.addGrammarElement("ajaxCmd", function (parser, tokens) {
+            if (tokens.matchToken("ajax")) {
+                var method = tokens.matchToken("GET") || tokens.matchToken("POST");
+                if (method == null) {
+                    parser.raiseParseError(tokens, "Requires either GET or POST");
+                }
+                if (method.value !== "GET") {
+                    if (!tokens.matchToken("to")) {
+                        var data = parser.parseElement("expression", tokens);
+                        tokens.requireToken("to");
+                    }
+                }
+                var url = parser.parseElement("string", tokens);
+                if (url == null) {
+                    var url = parser.parseElement("nakedString", tokens);
+                }
+                return {
+                    type: "requestCommand",
+                    method: method,
+                    transpile: function () {
+                        var capturedNext = this.next;
+                        delete this.next;
+                        return "_hyperscript.runtime.ajax('" + method.value + "', " +
+                            parser.transpile(url) + ", " +
+                            "function(response, xhr){ " + parser.transpile(capturedNext) + " }," +
+                            parser.transpile(data, "null") + ")";
+                    }
+                };
             }
-
-            return {
-                lexer: _lexer,
-                parser: _parser,
-                runtime: _runtime,
-                evaluate: evaluate,
-                init: init,
-                start: start
+        });
+        //-----------------------------------------------
+        // API
+        //-----------------------------------------------
+        function start(scriptAttrs) {
+            if (scriptAttrs) {
+                _runtime.setScriptAttrs(scriptAttrs);
             }
+            var fn = function () {
+                var elements = document.querySelectorAll(_runtime.getScriptSelector());
+                _runtime.forEach(elements, function (elt) {
+                    init(elt);
+                });
+            };
+            if (document.readyState !== 'loading') {
+                fn();
+            }
+            else {
+                document.addEventListener('DOMContentLoaded', fn);
+            }
+            return true;
         }
-    )()
+        function init(elt) {
+            _runtime.initElement(elt);
+        }
+        function evaluate(str) {
+            return _runtime.evaluate(str);
+        }
+        return {
+            lexer: _lexer,
+            parser: _parser,
+            runtime: _runtime,
+            evaluate: evaluate,
+            init: init,
+            start: start
+        };
+    })();
 }));
+/*********************************
+Interfaces
+
+This file defines all of the interfaces and types used in Hyperscript.
+No runnable code should go here.
+*/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "hypescript",
-  "version": "0.0.1",
+  "name": "hyperscript.org",
+  "version": "0.0.1-alpha2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16,38 +16,38 @@
       "integrity": "sha512-GOgG5ZvFfdJ4fMDlF+OHLQyvwu4cDkCdE8U0x/cfKze2Bu+27htaJ7qW8XbaGArySlBvYGhJD/z8vjdn/+hpLw==",
       "dev": true,
       "requires": {
-        "@11ty/dependency-tree": "1.0.0",
-        "browser-sync": "2.26.7",
-        "chalk": "3.0.0",
-        "chokidar": "3.4.0",
-        "debug": "4.1.1",
-        "dependency-graph": "0.8.1",
-        "ejs": "2.7.4",
-        "fast-glob": "3.2.2",
-        "fs-extra": "8.1.0",
-        "gray-matter": "4.0.2",
-        "hamljs": "0.6.2",
-        "handlebars": "4.7.6",
-        "javascript-stringify": "2.0.1",
-        "liquidjs": "6.4.3",
-        "lodash": "4.17.15",
-        "luxon": "1.24.1",
-        "markdown-it": "8.4.2",
-        "minimist": "1.2.5",
-        "moo": "0.5.1",
-        "multimatch": "4.0.0",
-        "mustache": "2.3.2",
-        "normalize-path": "3.0.0",
-        "nunjucks": "3.2.1",
-        "parse-filepath": "1.0.2",
-        "please-upgrade-node": "3.2.0",
-        "pretty": "2.0.0",
-        "pug": "2.0.4",
-        "recursive-copy": "2.0.10",
-        "semver": "7.3.2",
-        "slugify": "1.4.0",
-        "time-require": "0.1.2",
-        "valid-url": "1.0.9"
+        "@11ty/dependency-tree": "^1.0.0",
+        "browser-sync": "^2.26.7",
+        "chalk": "^3.0.0",
+        "chokidar": "^3.3.1",
+        "debug": "^4.1.1",
+        "dependency-graph": "^0.8.1",
+        "ejs": "^2.6.2",
+        "fast-glob": "^3.1.1",
+        "fs-extra": "^8.1.0",
+        "gray-matter": "^4.0.2",
+        "hamljs": "^0.6.2",
+        "handlebars": "^4.5.3",
+        "javascript-stringify": "^2.0.1",
+        "liquidjs": "^6.4.3",
+        "lodash": "^4.17.15",
+        "luxon": "^1.21.3",
+        "markdown-it": "^8.4.2",
+        "minimist": "^1.2.0",
+        "moo": "^0.5.1",
+        "multimatch": "^4.0.0",
+        "mustache": "^2.3.0",
+        "normalize-path": "^3.0.0",
+        "nunjucks": "^3.2.0",
+        "parse-filepath": "^1.0.2",
+        "please-upgrade-node": "^3.2.0",
+        "pretty": "^2.0.0",
+        "pug": "^2.0.4",
+        "recursive-copy": "^2.0.10",
+        "semver": "^7.1.0",
+        "slugify": "^1.3.6",
+        "time-require": "^0.1.2",
+        "valid-url": "^1.0.9"
       },
       "dependencies": {
         "fs-extra": {
@@ -56,9 +56,9 @@
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.4",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.2"
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "jsonfile": {
@@ -67,7 +67,7 @@
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.4"
+            "graceful-fs": "^4.1.6"
           }
         }
       }
@@ -78,11 +78,11 @@
       "integrity": "sha512-ciiioYMLdo16ShmfHBXJBOFm3xPC4AuwO4xeRpFeHz7WK9PYsWCmigagG2XyzZpubK4a3qNKoUBDhbzHfa50LQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.4",
-        "css": "2.2.4",
-        "normalize-path": "2.1.1",
-        "source-map": "0.6.1",
-        "through2": "2.0.5"
+        "acorn": "^5.0.3",
+        "css": "^2.2.1",
+        "normalize-path": "^2.1.1",
+        "source-map": "^0.6.0",
+        "through2": "^2.0.3"
       },
       "dependencies": {
         "acorn": {
@@ -97,7 +97,7 @@
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "1.1.0"
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "source-map": {
@@ -112,8 +112,8 @@
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.7",
-            "xtend": "4.0.2"
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -124,8 +124,8 @@
       "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
       "dev": true,
       "requires": {
-        "normalize-path": "2.1.1",
-        "through2": "2.0.5"
+        "normalize-path": "^2.0.1",
+        "through2": "^2.0.3"
       },
       "dependencies": {
         "normalize-path": {
@@ -134,7 +134,7 @@
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "1.1.0"
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "through2": {
@@ -143,8 +143,8 @@
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.7",
-            "xtend": "4.0.2"
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -156,7 +156,7 @@
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "2.0.3",
-        "run-parallel": "1.1.9"
+        "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
@@ -172,13 +172,13 @@
       "dev": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.3",
-        "fastq": "1.8.0"
+        "fastq": "^1.6.0"
       }
     },
     "@sinonjs/commons": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
-      "integrity": "sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -190,7 +190,7 @@
       "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "1.8.0"
+        "@sinonjs/commons": "^1.7.0"
       }
     },
     "@sinonjs/formatio": {
@@ -199,8 +199,8 @@
       "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "1.8.0",
-        "@sinonjs/samsam": "5.0.3"
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
       }
     },
     "@sinonjs/samsam": {
@@ -209,9 +209,9 @@
       "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "1.8.0",
-        "lodash.get": "4.4.2",
-        "type-detect": "4.0.8"
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
       }
     },
     "@sinonjs/text-encoding": {
@@ -232,7 +232,7 @@
       "integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "7.0.7"
+        "@types/babel-types": "*"
       }
     },
     "@types/color-name": {
@@ -271,7 +271,7 @@
       "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.27",
+        "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
       }
     },
@@ -287,7 +287,7 @@
       "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -310,10 +310,10 @@
       "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "3.1.1",
-        "fast-json-stable-stringify": "2.1.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "align-text": {
@@ -322,9 +322,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       },
       "dependencies": {
         "kind-of": {
@@ -333,7 +333,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -350,7 +350,7 @@
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "dev": true,
       "requires": {
-        "ansi-wrap": "0.1.0"
+        "ansi-wrap": "^0.1.0"
       }
     },
     "ansi-gray": {
@@ -386,8 +386,8 @@
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
       "requires": {
-        "micromatch": "3.1.10",
-        "normalize-path": "2.1.1"
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
       },
       "dependencies": {
         "normalize-path": {
@@ -396,7 +396,7 @@
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "1.1.0"
+            "remove-trailing-separator": "^1.0.1"
           }
         }
       }
@@ -407,7 +407,7 @@
       "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
       "dev": true,
       "requires": {
-        "buffer-equal": "1.0.0"
+        "buffer-equal": "^1.0.0"
       }
     },
     "aproba": {
@@ -422,8 +422,8 @@
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.7"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -432,7 +432,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -507,7 +507,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "assert-plus": {
@@ -582,13 +582,13 @@
       "integrity": "sha512-D96ZiIHXbDmU02dBaemyAg53ez+6F5yZmapmgKcjm35yEe1uVDYI8hGW3VYoGRaG290ZFf91YxHrR518vC0u/A==",
       "dev": true,
       "requires": {
-        "browserslist": "4.12.0",
-        "caniuse-lite": "1.0.30001066",
-        "chalk": "2.4.2",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "7.0.31",
-        "postcss-value-parser": "4.1.0"
+        "browserslist": "^4.12.0",
+        "caniuse-lite": "^1.0.30001061",
+        "chalk": "^2.4.2",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^7.0.30",
+        "postcss-value-parser": "^4.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -597,7 +597,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -606,9 +606,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "color-convert": {
@@ -638,7 +638,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -662,7 +662,7 @@
       "dev": true,
       "requires": {
         "follow-redirects": "1.5.10",
-        "is-buffer": "2.0.4"
+        "is-buffer": "^2.0.2"
       },
       "dependencies": {
         "is-buffer": {
@@ -679,8 +679,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.6.11",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-types": {
@@ -689,10 +689,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.3",
-        "lodash": "4.17.15",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -719,13 +719,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.2",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -734,7 +734,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -743,7 +743,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -752,7 +752,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -761,9 +761,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.3"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -792,7 +792,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "better-assert": {
@@ -832,7 +832,7 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4"
+        "inherits": "~2.0.0"
       }
     },
     "brace-expansion": {
@@ -841,7 +841,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -851,16 +851,16 @@
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "extend-shallow": "2.0.1",
-        "fill-range": "4.0.0",
-        "isobject": "3.0.1",
-        "repeat-element": "1.1.3",
-        "snapdragon": "0.8.2",
-        "snapdragon-node": "2.1.1",
-        "split-string": "3.1.0",
-        "to-regex": "3.0.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -869,7 +869,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -886,27 +886,27 @@
       "integrity": "sha512-lY3emme0OyvA2ujEMpRmyRy9LY6gHLuTr2/ABxhIm3lADOiRXzP4dgekvnDrQqZ/Ec2Fz19lEjm6kglSG5766w==",
       "dev": true,
       "requires": {
-        "browser-sync-client": "2.26.6",
-        "browser-sync-ui": "2.26.4",
+        "browser-sync-client": "^2.26.6",
+        "browser-sync-ui": "^2.26.4",
         "bs-recipes": "1.3.4",
-        "bs-snippet-injector": "2.0.1",
-        "chokidar": "2.1.8",
+        "bs-snippet-injector": "^2.0.1",
+        "chokidar": "^2.0.4",
         "connect": "3.6.6",
-        "connect-history-api-fallback": "1.6.0",
-        "dev-ip": "1.0.1",
-        "easy-extender": "2.3.4",
-        "eazy-logger": "3.0.2",
-        "etag": "1.8.1",
-        "fresh": "0.5.2",
+        "connect-history-api-fallback": "^1",
+        "dev-ip": "^1.0.1",
+        "easy-extender": "^2.3.4",
+        "eazy-logger": "^3",
+        "etag": "^1.8.1",
+        "fresh": "^0.5.2",
         "fs-extra": "3.0.1",
         "http-proxy": "1.15.2",
-        "immutable": "3.8.2",
+        "immutable": "^3",
         "localtunnel": "1.9.2",
-        "micromatch": "3.1.10",
+        "micromatch": "^3.1.10",
         "opn": "5.3.0",
         "portscanner": "2.1.1",
         "qs": "6.2.3",
-        "raw-body": "2.4.1",
+        "raw-body": "^2.3.2",
         "resp-modifier": "6.0.2",
         "rx": "4.1.0",
         "send": "0.16.2",
@@ -924,18 +924,18 @@
           "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
           "dev": true,
           "requires": {
-            "anymatch": "2.0.0",
-            "async-each": "1.0.3",
-            "braces": "2.3.2",
-            "fsevents": "1.2.13",
-            "glob-parent": "3.1.0",
-            "inherits": "2.0.4",
-            "is-binary-path": "1.0.1",
-            "is-glob": "4.0.1",
-            "normalize-path": "3.0.0",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.2.1",
-            "upath": "1.2.0"
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
           }
         },
         "fs-extra": {
@@ -944,9 +944,9 @@
           "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.4",
-            "jsonfile": "3.0.1",
-            "universalify": "0.1.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^3.0.0",
+            "universalify": "^0.1.0"
           }
         }
       }
@@ -959,8 +959,8 @@
       "requires": {
         "etag": "1.8.1",
         "fresh": "0.5.2",
-        "mitt": "1.2.0",
-        "rxjs": "5.5.12"
+        "mitt": "^1.1.3",
+        "rxjs": "^5.5.6"
       }
     },
     "browser-sync-ui": {
@@ -970,11 +970,11 @@
       "dev": true,
       "requires": {
         "async-each-series": "0.1.1",
-        "connect-history-api-fallback": "1.6.0",
-        "immutable": "3.8.2",
+        "connect-history-api-fallback": "^1",
+        "immutable": "^3",
         "server-destroy": "1.0.1",
-        "socket.io-client": "2.3.0",
-        "stream-throttle": "0.1.3"
+        "socket.io-client": "^2.0.4",
+        "stream-throttle": "^0.1.3"
       }
     },
     "browserslist": {
@@ -983,10 +983,10 @@
       "integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30001066",
-        "electron-to-chromium": "1.3.453",
-        "node-releases": "1.1.57",
-        "pkg-up": "2.0.0"
+        "caniuse-lite": "^1.0.30001043",
+        "electron-to-chromium": "^1.3.413",
+        "node-releases": "^1.1.53",
+        "pkg-up": "^2.0.0"
       }
     },
     "bs-recipes": {
@@ -1019,15 +1019,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.1",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.1",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "callsite": {
@@ -1048,8 +1048,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -1078,8 +1078,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chai": {
@@ -1088,12 +1088,12 @@
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
       }
     },
     "chalk": {
@@ -1102,8 +1102,8 @@
       "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "dev": true,
       "requires": {
-        "ansi-styles": "4.2.1",
-        "supports-color": "7.1.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1112,8 +1112,8 @@
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "@types/color-name": "1.1.1",
-            "color-convert": "2.0.1"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
         "supports-color": {
@@ -1122,7 +1122,7 @@
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
-            "has-flag": "4.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -1133,7 +1133,7 @@
       "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
       "dev": true,
       "requires": {
-        "is-regex": "1.0.5"
+        "is-regex": "^1.0.3"
       }
     },
     "check-error": {
@@ -1148,14 +1148,14 @@
       "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
       "dev": true,
       "requires": {
-        "anymatch": "3.1.1",
-        "braces": "3.0.2",
-        "fsevents": "2.1.3",
-        "glob-parent": "5.1.1",
-        "is-binary-path": "2.1.0",
-        "is-glob": "4.0.1",
-        "normalize-path": "3.0.0",
-        "readdirp": "3.4.0"
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.4.0"
       },
       "dependencies": {
         "anymatch": {
@@ -1164,8 +1164,8 @@
           "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
           "dev": true,
           "requires": {
-            "normalize-path": "3.0.0",
-            "picomatch": "2.2.2"
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
           }
         },
         "binary-extensions": {
@@ -1180,7 +1180,7 @@
           "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "dev": true,
           "requires": {
-            "fill-range": "7.0.1"
+            "fill-range": "^7.0.1"
           }
         },
         "fill-range": {
@@ -1189,7 +1189,7 @@
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
           "requires": {
-            "to-regex-range": "5.0.1"
+            "to-regex-range": "^5.0.1"
           }
         },
         "fsevents": {
@@ -1205,7 +1205,7 @@
           "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
           "dev": true,
           "requires": {
-            "is-glob": "4.0.1"
+            "is-glob": "^4.0.1"
           }
         },
         "is-binary-path": {
@@ -1214,7 +1214,7 @@
           "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
           "dev": true,
           "requires": {
-            "binary-extensions": "2.0.0"
+            "binary-extensions": "^2.0.0"
           }
         },
         "is-number": {
@@ -1229,7 +1229,7 @@
           "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
           "dev": true,
           "requires": {
-            "picomatch": "2.2.2"
+            "picomatch": "^2.2.1"
           }
         },
         "to-regex-range": {
@@ -1238,7 +1238,7 @@
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "dev": true,
           "requires": {
-            "is-number": "7.0.0"
+            "is-number": "^7.0.0"
           }
         }
       }
@@ -1249,11 +1249,11 @@
       "integrity": "sha512-jx0kJDCXdB2ARcDMwNCtrf04oY1Up4rOmVu+fqJ5MTPOOIG8EhRcEU9NZfXZc6dMw9FU8o1r21PNp8V2M0zQ+g==",
       "dev": true,
       "requires": {
-        "@types/node": "14.0.5",
-        "is-wsl": "2.2.0",
-        "lighthouse-logger": "1.2.0",
+        "@types/node": "*",
+        "is-wsl": "^2.1.0",
+        "lighthouse-logger": "^1.0.0",
         "mkdirp": "0.5.1",
-        "rimraf": "2.7.1"
+        "rimraf": "^2.6.1"
       },
       "dependencies": {
         "is-wsl": {
@@ -1262,7 +1262,7 @@
           "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
           "dev": true,
           "requires": {
-            "is-docker": "2.0.0"
+            "is-docker": "^2.0.0"
           }
         },
         "minimist": {
@@ -1288,8 +1288,8 @@
       "integrity": "sha512-F7mjof7rWvRNsJqhVXuiFU/HWySCxTA9tzpLxUJxVfdLkljwFJ1aMp08AnwXRmmP7r12/doTDOMwaNhFCJsacw==",
       "dev": true,
       "requires": {
-        "commander": "2.11.0",
-        "ws": "7.3.0"
+        "commander": "2.11.x",
+        "ws": "^7.2.0"
       },
       "dependencies": {
         "commander": {
@@ -1318,10 +1318,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1330,7 +1330,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -1341,7 +1341,7 @@
       "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
       "dev": true,
       "requires": {
-        "source-map": "0.6.1"
+        "source-map": "~0.6.0"
       },
       "dependencies": {
         "source-map": {
@@ -1358,9 +1358,9 @@
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
       }
     },
     "clone": {
@@ -1387,9 +1387,9 @@
       "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "process-nextick-args": "2.0.1",
-        "readable-stream": "2.3.7"
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^2.0.0",
+        "readable-stream": "^2.3.5"
       }
     },
     "code-point-at": {
@@ -1404,8 +1404,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color-convert": {
@@ -1414,7 +1414,7 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.4"
+        "color-name": "~1.1.4"
       }
     },
     "color-name": {
@@ -1435,7 +1435,7 @@
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -1474,9 +1474,9 @@
       "integrity": "sha1-PemFVTE5R10yUCyDsC9gaE0kxV8=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-whitespace": "0.3.0",
-        "kind-of": "3.2.2"
+        "extend-shallow": "^2.0.1",
+        "is-whitespace": "^0.3.0",
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1485,7 +1485,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "kind-of": {
@@ -1494,7 +1494,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -1505,8 +1505,8 @@
       "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
       "dev": true,
       "requires": {
-        "ini": "1.3.5",
-        "proto-list": "1.2.4"
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
       }
     },
     "connect": {
@@ -1517,7 +1517,7 @@
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
-        "parseurl": "1.3.3",
+        "parseurl": "~1.3.2",
         "utils-merge": "1.0.1"
       },
       "dependencies": {
@@ -1556,10 +1556,10 @@
       "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "7.0.7",
-        "@types/babylon": "6.16.5",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0"
+        "@types/babel-types": "^7.0.0",
+        "@types/babylon": "^6.16.2",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0"
       }
     },
     "convert-source-map": {
@@ -1568,7 +1568,7 @@
       "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.1"
       }
     },
     "cookie": {
@@ -1601,8 +1601,8 @@
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.5",
-        "which": "1.3.1"
+        "lru-cache": "^4.0.1",
+        "which": "^1.2.9"
       }
     },
     "css": {
@@ -1611,10 +1611,10 @@
       "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "source-map": "0.6.1",
-        "source-map-resolve": "0.5.3",
-        "urix": "0.1.0"
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
+        "urix": "^0.1.0"
       },
       "dependencies": {
         "source-map": {
@@ -1631,7 +1631,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "d": {
@@ -1640,8 +1640,8 @@
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.53",
-        "type": "1.2.0"
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
       }
     },
     "dashdash": {
@@ -1650,7 +1650,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-time": {
@@ -1665,7 +1665,7 @@
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "requires": {
-        "ms": "2.1.2"
+        "ms": "^2.1.1"
       }
     },
     "debug-fabulous": {
@@ -1674,9 +1674,9 @@
       "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
       "dev": true,
       "requires": {
-        "debug": "3.2.6",
-        "memoizee": "0.4.14",
-        "object-assign": "4.1.1"
+        "debug": "3.X",
+        "memoizee": "0.4.X",
+        "object-assign": "4.X"
       },
       "dependencies": {
         "debug": {
@@ -1685,7 +1685,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         }
       }
@@ -1702,8 +1702,8 @@
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
-        "decamelize": "1.2.0",
-        "map-obj": "1.0.1"
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
       }
     },
     "decode-uri-component": {
@@ -1718,7 +1718,7 @@
       "integrity": "sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==",
       "dev": true,
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "deep-eql": {
@@ -1727,7 +1727,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "define-properties": {
@@ -1736,7 +1736,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "1.1.1"
+        "object-keys": "^1.0.12"
       }
     },
     "define-property": {
@@ -1745,8 +1745,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -1755,7 +1755,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1764,7 +1764,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1773,9 +1773,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.3"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -1786,13 +1786,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.7.1"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -1855,10 +1855,10 @@
       "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.4",
-        "inherits": "2.0.4",
-        "readable-stream": "3.6.0",
-        "stream-shift": "1.0.1"
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
       },
       "dependencies": {
         "readable-stream": {
@@ -1867,9 +1867,9 @@
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.4",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
@@ -1880,7 +1880,7 @@
       "integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.15"
+        "lodash": "^4.17.10"
       }
     },
     "eazy-logger": {
@@ -1889,7 +1889,7 @@
       "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
       "dev": true,
       "requires": {
-        "tfunk": "3.1.0"
+        "tfunk": "^3.0.1"
       }
     },
     "ecc-jsbn": {
@@ -1898,8 +1898,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "editorconfig": {
@@ -1908,10 +1908,10 @@
       "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
       "dev": true,
       "requires": {
-        "commander": "2.20.3",
-        "lru-cache": "4.1.5",
-        "semver": "5.7.1",
-        "sigmund": "1.0.1"
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
       },
       "dependencies": {
         "semver": {
@@ -1946,15 +1946,15 @@
       "integrity": "sha512-q2OjmIue6+uVc+zKTfnSQkXwqbnEbxGB3PTb+y1R24ecU+hF1oVkQmuNaJeDm6lL2PHi5B45q6WBSnuRdad2Ug==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "chokidar": "3.4.0",
-        "gulp-autoprefixer": "7.0.1",
-        "gulp-clean-css": "4.3.0",
-        "gulp-if": "3.0.0",
-        "gulp-sass": "4.1.0",
-        "gulp-sourcemaps": "2.6.5",
-        "lodash.debounce": "4.0.8",
-        "vinyl-fs": "3.0.3"
+        "chalk": "^2.4.2",
+        "chokidar": "^3.2.1",
+        "gulp-autoprefixer": "^7.0.1",
+        "gulp-clean-css": "^4.2.0",
+        "gulp-if": "^3.0.0",
+        "gulp-sass": "^4.0.2",
+        "gulp-sourcemaps": "^2.6.5",
+        "lodash.debounce": "^4.0.8",
+        "vinyl-fs": "^3.0.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1963,7 +1963,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -1972,9 +1972,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "color-convert": {
@@ -2004,7 +2004,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -2033,7 +2033,7 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "engine.io": {
@@ -2042,12 +2042,12 @@
       "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
       "dev": true,
       "requires": {
-        "accepts": "1.3.7",
+        "accepts": "~1.3.4",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "3.1.0",
-        "engine.io-parser": "2.1.3",
-        "ws": "3.3.3"
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.0",
+        "ws": "~3.3.1"
       },
       "dependencies": {
         "debug": {
@@ -2066,10 +2066,10 @@
           "dev": true,
           "requires": {
             "after": "0.8.2",
-            "arraybuffer.slice": "0.0.7",
+            "arraybuffer.slice": "~0.0.7",
             "base64-arraybuffer": "0.1.5",
             "blob": "0.0.5",
-            "has-binary2": "1.0.3"
+            "has-binary2": "~1.0.2"
           }
         },
         "ms": {
@@ -2084,9 +2084,9 @@
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "dev": true,
           "requires": {
-            "async-limiter": "1.0.1",
-            "safe-buffer": "5.1.2",
-            "ultron": "1.1.1"
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
           }
         }
       }
@@ -2097,16 +2097,16 @@
       "integrity": "sha512-AWjc1Xg06a6UPFOBAzJf48W1UR/qKYmv/ubgSCumo9GXgvL/xGIvo05dXoBL+2NTLMipDI7in8xK61C17L25xg==",
       "dev": true,
       "requires": {
-        "component-emitter": "1.3.0",
+        "component-emitter": "~1.3.0",
         "component-inherit": "0.0.3",
-        "debug": "4.1.1",
-        "engine.io-parser": "2.2.0",
+        "debug": "~4.1.0",
+        "engine.io-parser": "~2.2.0",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "6.1.4",
-        "xmlhttprequest-ssl": "1.5.5",
+        "ws": "~6.1.0",
+        "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -2125,10 +2125,10 @@
       "dev": true,
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "0.0.7",
+        "arraybuffer.slice": "~0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.5",
-        "has-binary2": "1.0.3"
+        "has-binary2": "~1.0.2"
       }
     },
     "entities": {
@@ -2143,7 +2143,7 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -2152,26 +2152,37 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
-      "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.2.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "has-symbols": "1.0.1",
-        "is-callable": "1.1.5",
-        "is-regex": "1.0.5",
-        "object-inspect": "1.7.0",
-        "object-keys": "1.1.1",
-        "object.assign": "4.1.0",
-        "string.prototype.trimleft": "2.1.2",
-        "string.prototype.trimright": "2.1.2"
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      },
+      "dependencies": {
+        "is-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        }
       }
     },
     "es-to-primitive": {
@@ -2180,9 +2191,9 @@
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.5",
-        "is-date-object": "1.0.2",
-        "is-symbol": "1.0.3"
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "es5-ext": {
@@ -2191,9 +2202,9 @@
       "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.3",
-        "next-tick": "1.0.0"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
       },
       "dependencies": {
         "next-tick": {
@@ -2210,9 +2221,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.1",
-        "es5-ext": "0.10.53",
-        "es6-symbol": "3.1.3"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-symbol": {
@@ -2221,8 +2232,8 @@
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
       "dev": true,
       "requires": {
-        "d": "1.0.1",
-        "ext": "1.4.0"
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
       }
     },
     "es6-weak-map": {
@@ -2231,10 +2242,10 @@
       "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
       "dev": true,
       "requires": {
-        "d": "1.0.1",
-        "es5-ext": "0.10.53",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.3"
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-html": {
@@ -2273,8 +2284,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.1",
-        "es5-ext": "0.10.53"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "eventemitter3": {
@@ -2289,13 +2300,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "debug": {
@@ -2313,7 +2324,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -2322,7 +2333,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "ms": {
@@ -2339,7 +2350,7 @@
       "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
       "dev": true,
       "requires": {
-        "type": "2.0.0"
+        "type": "^2.0.0"
       },
       "dependencies": {
         "type": {
@@ -2362,8 +2373,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -2372,7 +2383,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -2383,14 +2394,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "expand-brackets": "2.1.4",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -2399,7 +2410,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "extend-shallow": {
@@ -2408,7 +2419,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -2417,7 +2428,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -2426,7 +2437,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -2435,9 +2446,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.3"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -2454,10 +2465,10 @@
       "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
       "dev": true,
       "requires": {
-        "ansi-gray": "0.1.1",
-        "color-support": "1.1.3",
-        "parse-node-version": "1.0.1",
-        "time-stamp": "1.1.0"
+        "ansi-gray": "^0.1.1",
+        "color-support": "^1.1.3",
+        "parse-node-version": "^1.0.0",
+        "time-stamp": "^1.0.0"
       }
     },
     "fast-deep-equal": {
@@ -2472,12 +2483,12 @@
       "integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
       "dev": true,
       "requires": {
-        "@nodelib/fs.stat": "2.0.3",
-        "@nodelib/fs.walk": "1.2.4",
-        "glob-parent": "5.1.1",
-        "merge2": "1.3.0",
-        "micromatch": "4.0.2",
-        "picomatch": "2.2.2"
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
       },
       "dependencies": {
         "braces": {
@@ -2486,7 +2497,7 @@
           "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "dev": true,
           "requires": {
-            "fill-range": "7.0.1"
+            "fill-range": "^7.0.1"
           }
         },
         "fill-range": {
@@ -2495,7 +2506,7 @@
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
           "requires": {
-            "to-regex-range": "5.0.1"
+            "to-regex-range": "^5.0.1"
           }
         },
         "glob-parent": {
@@ -2504,7 +2515,7 @@
           "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
           "dev": true,
           "requires": {
-            "is-glob": "4.0.1"
+            "is-glob": "^4.0.1"
           }
         },
         "is-number": {
@@ -2519,8 +2530,8 @@
           "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
           "dev": true,
           "requires": {
-            "braces": "3.0.2",
-            "picomatch": "2.2.2"
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
           }
         },
         "to-regex-range": {
@@ -2529,7 +2540,7 @@
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "dev": true,
           "requires": {
-            "is-number": "7.0.0"
+            "is-number": "^7.0.0"
           }
         }
       }
@@ -2546,7 +2557,7 @@
       "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
       "dev": true,
       "requires": {
-        "reusify": "1.0.4"
+        "reusify": "^1.0.4"
       }
     },
     "file-uri-to-path": {
@@ -2562,10 +2573,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2574,7 +2585,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -2586,12 +2597,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.3",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -2617,8 +2628,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "flat": {
@@ -2627,7 +2638,7 @@
       "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
       "dev": true,
       "requires": {
-        "is-buffer": "2.0.4"
+        "is-buffer": "~2.0.3"
       },
       "dependencies": {
         "is-buffer": {
@@ -2644,8 +2655,8 @@
       "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.7"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
       }
     },
     "follow-redirects": {
@@ -2654,7 +2665,7 @@
       "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "dev": true,
       "requires": {
-        "debug": "3.1.0"
+        "debug": "=3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -2698,9 +2709,9 @@
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.8",
-        "mime-types": "2.1.27"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "fragment-cache": {
@@ -2709,7 +2720,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fresh": {
@@ -2724,10 +2735,10 @@
       "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
       "dev": true,
       "requires": {
-        "at-least-node": "1.0.0",
-        "graceful-fs": "4.2.4",
-        "jsonfile": "6.0.1",
-        "universalify": "1.0.0"
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
       },
       "dependencies": {
         "jsonfile": {
@@ -2736,8 +2747,8 @@
           "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.4",
-            "universalify": "1.0.0"
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
           }
         },
         "universalify": {
@@ -2754,8 +2765,8 @@
       "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.4",
-        "through2": "2.0.5"
+        "graceful-fs": "^4.1.11",
+        "through2": "^2.0.3"
       },
       "dependencies": {
         "through2": {
@@ -2764,8 +2775,8 @@
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.7",
-            "xtend": "4.0.2"
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -2783,8 +2794,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bindings": "1.5.0",
-        "nan": "2.14.1"
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
       }
     },
     "fstream": {
@@ -2793,10 +2804,10 @@
       "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.4",
-        "inherits": "2.0.4",
-        "mkdirp": "0.5.5",
-        "rimraf": "2.7.1"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       },
       "dependencies": {
         "mkdirp": {
@@ -2805,7 +2816,7 @@
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "1.2.5"
+            "minimist": "^1.2.5"
           }
         }
       }
@@ -2822,14 +2833,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.3",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.3"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "gaze": {
@@ -2838,7 +2849,7 @@
       "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
       "dev": true,
       "requires": {
-        "globule": "1.3.1"
+        "globule": "^1.0.0"
       }
     },
     "get-caller-file": {
@@ -2871,7 +2882,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -2880,12 +2891,12 @@
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.4",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-parent": {
@@ -2894,8 +2905,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "3.1.0",
-        "path-dirname": "1.0.2"
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
       },
       "dependencies": {
         "is-glob": {
@@ -2904,7 +2915,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         }
       }
@@ -2915,16 +2926,16 @@
       "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
       "dev": true,
       "requires": {
-        "extend": "3.0.2",
-        "glob": "7.1.6",
-        "glob-parent": "3.1.0",
-        "is-negated-glob": "1.0.0",
-        "ordered-read-streams": "1.0.1",
-        "pumpify": "1.5.1",
-        "readable-stream": "2.3.7",
-        "remove-trailing-separator": "1.1.0",
-        "to-absolute-glob": "2.0.2",
-        "unique-stream": "2.3.1"
+        "extend": "^3.0.0",
+        "glob": "^7.1.1",
+        "glob-parent": "^3.1.0",
+        "is-negated-glob": "^1.0.0",
+        "ordered-read-streams": "^1.0.0",
+        "pumpify": "^1.3.5",
+        "readable-stream": "^2.1.5",
+        "remove-trailing-separator": "^1.0.1",
+        "to-absolute-glob": "^2.0.0",
+        "unique-stream": "^2.0.2"
       }
     },
     "globby": {
@@ -2933,12 +2944,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.6",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "array-union": {
@@ -2947,7 +2958,7 @@
           "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
           "dev": true,
           "requires": {
-            "array-uniq": "1.0.3"
+            "array-uniq": "^1.0.1"
           }
         },
         "arrify": {
@@ -2964,9 +2975,9 @@
       "integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
       "dev": true,
       "requires": {
-        "glob": "7.1.6",
-        "lodash": "4.17.15",
-        "minimatch": "3.0.4"
+        "glob": "~7.1.1",
+        "lodash": "~4.17.12",
+        "minimatch": "~3.0.2"
       }
     },
     "graceful-fs": {
@@ -2981,10 +2992,10 @@
       "integrity": "sha512-7hB/+LxrOjq/dd8APlK0r24uL/67w7SkYnfwhNFwg/VDIGWGmduTDYf3WNstLW2fbbmRwrDGCVSJ2isuf2+4Hw==",
       "dev": true,
       "requires": {
-        "js-yaml": "3.14.0",
-        "kind-of": "6.0.3",
-        "section-matter": "1.0.0",
-        "strip-bom-string": "1.0.0"
+        "js-yaml": "^3.11.0",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
       }
     },
     "growl": {
@@ -2999,12 +3010,12 @@
       "integrity": "sha512-QJGEmHw+bEt7FSqvmbAUTxbCuNLJYx4sz3ox9WouYqT/7j5FH5CQ8ZnpL1M7H5npX1bUJa7lUVY1w20jXxhOxg==",
       "dev": true,
       "requires": {
-        "autoprefixer": "9.8.0",
-        "fancy-log": "1.3.3",
-        "plugin-error": "1.0.1",
-        "postcss": "7.0.31",
-        "through2": "3.0.1",
-        "vinyl-sourcemaps-apply": "0.2.1"
+        "autoprefixer": "^9.6.1",
+        "fancy-log": "^1.3.2",
+        "plugin-error": "^1.0.1",
+        "postcss": "^7.0.17",
+        "through2": "^3.0.1",
+        "vinyl-sourcemaps-apply": "^0.2.1"
       }
     },
     "gulp-clean-css": {
@@ -3025,9 +3036,9 @@
       "integrity": "sha512-fCUEngzNiEZEK2YuPm+sdMpO6ukb8+/qzbGfJBXyNOXz85bCG7yBI+pPSl+N90d7gnLvMsarthsAImx0qy7BAw==",
       "dev": true,
       "requires": {
-        "gulp-match": "1.1.0",
-        "ternary-stream": "3.0.0",
-        "through2": "3.0.1"
+        "gulp-match": "^1.1.0",
+        "ternary-stream": "^3.0.0",
+        "through2": "^3.0.1"
       }
     },
     "gulp-match": {
@@ -3036,7 +3047,7 @@
       "integrity": "sha512-DlyVxa1Gj24DitY2OjEsS+X6tDpretuxD6wTfhXE/Rw2hweqc1f6D/XtsJmoiCwLWfXgR87W9ozEityPCVzGtQ==",
       "dev": true,
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.3"
       }
     },
     "gulp-sass": {
@@ -3045,14 +3056,14 @@
       "integrity": "sha512-xIiwp9nkBLcJDpmYHbEHdoWZv+j+WtYaKD6Zil/67F3nrAaZtWYN5mDwerdo7EvcdBenSAj7Xb2hx2DqURLGdA==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "lodash": "4.17.15",
-        "node-sass": "4.14.1",
-        "plugin-error": "1.0.1",
-        "replace-ext": "1.0.1",
-        "strip-ansi": "4.0.0",
-        "through2": "2.0.5",
-        "vinyl-sourcemaps-apply": "0.2.1"
+        "chalk": "^2.3.0",
+        "lodash": "^4.17.11",
+        "node-sass": "^4.8.3",
+        "plugin-error": "^1.0.1",
+        "replace-ext": "^1.0.0",
+        "strip-ansi": "^4.0.0",
+        "through2": "^2.0.0",
+        "vinyl-sourcemaps-apply": "^0.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3067,7 +3078,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3076,9 +3087,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "color-convert": {
@@ -3108,7 +3119,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -3117,7 +3128,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "through2": {
@@ -3126,8 +3137,8 @@
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.7",
-            "xtend": "4.0.2"
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -3138,17 +3149,17 @@
       "integrity": "sha512-SYLBRzPTew8T5Suh2U8jCSDKY+4NARua4aqjj8HOysBh2tSgT9u4jc1FYirAdPx1akUxxDeK++fqw6Jg0LkQRg==",
       "dev": true,
       "requires": {
-        "@gulp-sourcemaps/identity-map": "1.0.2",
-        "@gulp-sourcemaps/map-sources": "1.0.0",
-        "acorn": "5.7.4",
-        "convert-source-map": "1.7.0",
-        "css": "2.2.4",
-        "debug-fabulous": "1.1.0",
-        "detect-newline": "2.1.0",
-        "graceful-fs": "4.2.4",
-        "source-map": "0.6.1",
-        "strip-bom-string": "1.0.0",
-        "through2": "2.0.5"
+        "@gulp-sourcemaps/identity-map": "1.X",
+        "@gulp-sourcemaps/map-sources": "1.X",
+        "acorn": "5.X",
+        "convert-source-map": "1.X",
+        "css": "2.X",
+        "debug-fabulous": "1.X",
+        "detect-newline": "2.X",
+        "graceful-fs": "4.X",
+        "source-map": "~0.6.0",
+        "strip-bom-string": "1.X",
+        "through2": "2.X"
       },
       "dependencies": {
         "acorn": {
@@ -3169,8 +3180,8 @@
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.7",
-            "xtend": "4.0.2"
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -3187,11 +3198,11 @@
       "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
       "dev": true,
       "requires": {
-        "minimist": "1.2.5",
-        "neo-async": "2.6.1",
-        "source-map": "0.6.1",
-        "uglify-js": "3.9.4",
-        "wordwrap": "1.0.0"
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
         "source-map": {
@@ -3214,8 +3225,8 @@
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
-        "ajv": "6.12.2",
-        "har-schema": "2.0.0"
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -3224,7 +3235,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -3233,7 +3244,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-binary2": {
@@ -3281,9 +3292,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -3292,8 +3303,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3302,7 +3313,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -3325,10 +3336,10 @@
       "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
       "dev": true,
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.4",
         "setprototypeof": "1.1.1",
-        "statuses": "1.5.0",
+        "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
       },
       "dependencies": {
@@ -3346,8 +3357,8 @@
       "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
       "dev": true,
       "requires": {
-        "eventemitter3": "1.2.0",
-        "requires-port": "1.0.0"
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
       }
     },
     "http-signature": {
@@ -3356,9 +3367,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.16.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -3367,7 +3378,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "immutable": {
@@ -3382,8 +3393,8 @@
       "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "3.0.0",
-        "resolve-cwd": "2.0.0"
+        "pkg-dir": "^3.0.0",
+        "resolve-cwd": "^2.0.0"
       }
     },
     "in-publish": {
@@ -3398,7 +3409,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "indexof": {
@@ -3413,8 +3424,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -3441,8 +3452,8 @@
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "dev": true,
       "requires": {
-        "is-relative": "1.0.0",
-        "is-windows": "1.0.2"
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
       }
     },
     "is-accessor-descriptor": {
@@ -3451,7 +3462,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3460,7 +3471,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -3477,7 +3488,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.13.1"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -3487,9 +3498,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
       "dev": true
     },
     "is-data-descriptor": {
@@ -3498,7 +3509,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3507,7 +3518,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -3524,9 +3535,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3549,8 +3560,8 @@
       "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13",
-        "object-assign": "4.1.1"
+        "acorn": "~4.0.2",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "acorn": {
@@ -3585,7 +3596,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-glob": {
@@ -3594,7 +3605,7 @@
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.1"
       }
     },
     "is-negated-glob": {
@@ -3609,7 +3620,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3618,7 +3629,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -3629,7 +3640,7 @@
       "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
       "dev": true,
       "requires": {
-        "lodash.isfinite": "3.3.2"
+        "lodash.isfinite": "^3.3.2"
       }
     },
     "is-obj": {
@@ -3650,7 +3661,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -3659,7 +3670,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -3674,7 +3685,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-promise": {
@@ -3689,7 +3700,7 @@
       "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "dev": true,
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.3"
       }
     },
     "is-relative": {
@@ -3698,7 +3709,7 @@
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "dev": true,
       "requires": {
-        "is-unc-path": "1.0.0"
+        "is-unc-path": "^1.0.0"
       }
     },
     "is-symbol": {
@@ -3707,7 +3718,7 @@
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "dev": true,
       "requires": {
-        "has-symbols": "1.0.1"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-typedarray": {
@@ -3722,7 +3733,7 @@
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "dev": true,
       "requires": {
-        "unc-path-regex": "0.1.2"
+        "unc-path-regex": "^0.1.2"
       }
     },
     "is-utf8": {
@@ -3797,11 +3808,11 @@
       "integrity": "sha512-a26B+Cx7USQGSWnz9YxgJNMmML/QG2nqIaL7VVYPCXbqiKz8PN0waSNvroMtvAK6tY7g/wPdNWGEP+JTNIBr6A==",
       "dev": true,
       "requires": {
-        "config-chain": "1.1.12",
-        "editorconfig": "0.15.3",
-        "glob": "7.1.6",
-        "mkdirp": "1.0.4",
-        "nopt": "4.0.3"
+        "config-chain": "^1.1.12",
+        "editorconfig": "^0.15.3",
+        "glob": "^7.1.3",
+        "mkdirp": "~1.0.3",
+        "nopt": "^4.0.3"
       }
     },
     "js-stringify": {
@@ -3816,8 +3827,8 @@
       "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -3862,7 +3873,7 @@
       "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.4"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsprim": {
@@ -3883,8 +3894,8 @@
       "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
       "dev": true,
       "requires": {
-        "is-promise": "2.2.2",
-        "promise": "7.3.1"
+        "is-promise": "^2.0.0",
+        "promise": "^7.0.1"
       }
     },
     "junk": {
@@ -3917,7 +3928,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.7"
+        "readable-stream": "^2.0.5"
       }
     },
     "lcid": {
@@ -3926,7 +3937,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "lead": {
@@ -3935,7 +3946,7 @@
       "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
       "dev": true,
       "requires": {
-        "flush-write-stream": "1.1.1"
+        "flush-write-stream": "^1.0.2"
       }
     },
     "lighthouse-logger": {
@@ -3944,8 +3955,8 @@
       "integrity": "sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "marky": "1.2.1"
+        "debug": "^2.6.8",
+        "marky": "^1.2.0"
       },
       "dependencies": {
         "debug": {
@@ -3977,7 +3988,7 @@
       "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
       "dev": true,
       "requires": {
-        "uc.micro": "1.0.6"
+        "uc.micro": "^1.0.1"
       }
     },
     "liquidjs": {
@@ -3992,11 +4003,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.4",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "localtunnel": {
@@ -4017,19 +4028,19 @@
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.3",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^4.2.0"
           }
         }
       }
@@ -4040,8 +4051,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -4082,7 +4093,7 @@
       "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2"
+        "chalk": "^2.4.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4091,7 +4102,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -4100,9 +4111,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "color-convert": {
@@ -4132,7 +4143,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -4155,8 +4166,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.3"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lru-cache": {
@@ -4165,8 +4176,8 @@
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "lru-queue": {
@@ -4175,7 +4186,7 @@
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.53"
+        "es5-ext": "~0.10.2"
       }
     },
     "luxon": {
@@ -4202,7 +4213,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "markdown-it": {
@@ -4211,11 +4222,11 @@
       "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "entities": "1.1.2",
-        "linkify-it": "2.2.0",
-        "mdurl": "1.0.1",
-        "uc.micro": "1.0.6"
+        "argparse": "^1.0.7",
+        "entities": "~1.1.1",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
       }
     },
     "marky": {
@@ -4230,10 +4241,10 @@
       "integrity": "sha1-hs2NawTJ8wfAWmuUGZBtA2D7E6I=",
       "dev": true,
       "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
       },
       "dependencies": {
         "array-differ": {
@@ -4248,7 +4259,7 @@
           "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
           "dev": true,
           "requires": {
-            "array-uniq": "1.0.3"
+            "array-uniq": "^1.0.1"
           }
         },
         "arrify": {
@@ -4271,14 +4282,14 @@
       "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
       "dev": true,
       "requires": {
-        "d": "1.0.1",
-        "es5-ext": "0.10.53",
-        "es6-weak-map": "2.0.3",
-        "event-emitter": "0.3.5",
-        "is-promise": "2.2.2",
-        "lru-queue": "0.1.0",
-        "next-tick": "1.1.0",
-        "timers-ext": "0.1.7"
+        "d": "1",
+        "es5-ext": "^0.10.45",
+        "es6-weak-map": "^2.0.2",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.1",
+        "lru-queue": "0.1",
+        "next-tick": "1",
+        "timers-ext": "^0.1.5"
       }
     },
     "meow": {
@@ -4287,16 +4298,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.5",
-        "normalize-package-data": "2.5.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       }
     },
     "merge-stream": {
@@ -4317,19 +4328,19 @@
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "braces": "2.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "extglob": "2.0.4",
-        "fragment-cache": "0.2.1",
-        "kind-of": "6.0.3",
-        "nanomatch": "1.2.13",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "mime": {
@@ -4359,7 +4370,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -4374,8 +4385,8 @@
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "is-plain-obj": "1.1.0"
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
       },
       "dependencies": {
         "arrify": {
@@ -4398,8 +4409,8 @@
       "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -4408,7 +4419,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -4469,7 +4480,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "anymatch": {
@@ -4478,14 +4489,14 @@
           "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
           "dev": true,
           "requires": {
-            "normalize-path": "3.0.0",
-            "picomatch": "2.2.2"
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
           }
         },
         "binary-extensions": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+          "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
           "dev": true
         },
         "braces": {
@@ -4494,7 +4505,7 @@
           "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "dev": true,
           "requires": {
-            "fill-range": "7.0.1"
+            "fill-range": "^7.0.1"
           }
         },
         "camelcase": {
@@ -4509,14 +4520,14 @@
           "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
           "dev": true,
           "requires": {
-            "anymatch": "3.1.1",
-            "braces": "3.0.2",
-            "fsevents": "2.1.3",
-            "glob-parent": "5.1.1",
-            "is-binary-path": "2.1.0",
-            "is-glob": "4.0.1",
-            "normalize-path": "3.0.0",
-            "readdirp": "3.2.0"
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.1",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.2.0"
           }
         },
         "cliui": {
@@ -4525,9 +4536,9 @@
           "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
-            "string-width": "3.1.0",
-            "strip-ansi": "5.2.0",
-            "wrap-ansi": "5.1.0"
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
           }
         },
         "color-convert": {
@@ -4551,7 +4562,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "fill-range": {
@@ -4560,7 +4571,7 @@
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
           "requires": {
-            "to-regex-range": "5.0.1"
+            "to-regex-range": "^5.0.1"
           }
         },
         "find-up": {
@@ -4569,7 +4580,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "3.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "fsevents": {
@@ -4591,12 +4602,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.4",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "glob-parent": {
@@ -4605,7 +4616,7 @@
           "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
           "dev": true,
           "requires": {
-            "is-glob": "4.0.1"
+            "is-glob": "^4.0.1"
           }
         },
         "has-flag": {
@@ -4620,7 +4631,7 @@
           "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
           "dev": true,
           "requires": {
-            "binary-extensions": "2.0.0"
+            "binary-extensions": "^2.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -4641,8 +4652,8 @@
           "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.10",
-            "esprima": "4.0.1"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "locate-path": {
@@ -4651,8 +4662,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "3.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "mkdirp": {
@@ -4661,7 +4672,7 @@
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "1.2.5"
+            "minimist": "^1.2.5"
           }
         },
         "ms": {
@@ -4676,7 +4687,7 @@
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
-            "p-try": "2.2.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
@@ -4685,7 +4696,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "2.3.0"
+            "p-limit": "^2.0.0"
           }
         },
         "p-try": {
@@ -4706,7 +4717,7 @@
           "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
           "dev": true,
           "requires": {
-            "picomatch": "2.2.2"
+            "picomatch": "^2.0.4"
           }
         },
         "require-main-filename": {
@@ -4721,9 +4732,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -4732,7 +4743,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         },
         "supports-color": {
@@ -4741,7 +4752,7 @@
           "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "to-regex-range": {
@@ -4750,7 +4761,7 @@
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "dev": true,
           "requires": {
-            "is-number": "7.0.0"
+            "is-number": "^7.0.0"
           }
         },
         "which-module": {
@@ -4765,9 +4776,9 @@
           "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "string-width": "3.1.0",
-            "strip-ansi": "5.2.0"
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
           }
         },
         "y18n": {
@@ -4782,16 +4793,16 @@
           "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
           "dev": true,
           "requires": {
-            "cliui": "5.0.0",
-            "find-up": "3.0.0",
-            "get-caller-file": "2.0.5",
-            "require-directory": "2.1.1",
-            "require-main-filename": "2.0.0",
-            "set-blocking": "2.0.0",
-            "string-width": "3.1.0",
-            "which-module": "2.0.0",
-            "y18n": "4.0.0",
-            "yargs-parser": "13.1.2"
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
           }
         },
         "yargs-parser": {
@@ -4800,8 +4811,8 @@
           "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
           "dev": true,
           "requires": {
-            "camelcase": "5.3.1",
-            "decamelize": "1.2.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -4812,16 +4823,16 @@
       "integrity": "sha512-RXP6Q2mlM2X+eO2Z8gribmiH4J9x5zu/JcTZ3deQSwiC5260BzizOc0eD1NWP3JuypGCKRwReicv4KCNIFtTZQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "chrome-launcher": "0.11.2",
-        "chrome-remote-interface": "0.28.2",
-        "chrome-unmirror": "0.1.0",
-        "debug": "4.1.1",
-        "deep-assign": "3.0.0",
-        "import-local": "2.0.0",
-        "loglevel": "1.6.8",
-        "meow": "5.0.0",
-        "nanobus": "4.4.0"
+        "chalk": "^2.0.1",
+        "chrome-launcher": "^0.11.2",
+        "chrome-remote-interface": "^0.28.0",
+        "chrome-unmirror": "^0.1.0",
+        "debug": "^4.1.1",
+        "deep-assign": "^3.0.0",
+        "import-local": "^2.0.0",
+        "loglevel": "^1.4.1",
+        "meow": "^5.0.0",
+        "nanobus": "^4.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4830,7 +4841,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "camelcase": {
@@ -4845,9 +4856,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "map-obj": "2.0.0",
-            "quick-lru": "1.1.0"
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
           }
         },
         "chalk": {
@@ -4856,9 +4867,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "color-convert": {
@@ -4882,7 +4893,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "has-flag": {
@@ -4903,10 +4914,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.4",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "map-obj": {
@@ -4921,15 +4932,15 @@
           "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.5.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0",
-            "yargs-parser": "10.1.0"
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0",
+            "yargs-parser": "^10.0.0"
           }
         },
         "parse-json": {
@@ -4938,8 +4949,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.2",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -4948,7 +4959,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -4963,9 +4974,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.5.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -4974,8 +4985,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "redent": {
@@ -4984,8 +4995,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "3.2.0",
-            "strip-indent": "2.0.0"
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -5006,7 +5017,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "trim-newlines": {
@@ -5021,7 +5032,7 @@
           "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -5044,11 +5055,11 @@
       "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
       "dev": true,
       "requires": {
-        "@types/minimatch": "3.0.3",
-        "array-differ": "3.0.0",
-        "array-union": "2.1.0",
-        "arrify": "2.0.1",
-        "minimatch": "3.0.4"
+        "@types/minimatch": "^3.0.3",
+        "array-differ": "^3.0.0",
+        "array-union": "^2.1.0",
+        "arrify": "^2.0.1",
+        "minimatch": "^3.0.4"
       }
     },
     "mustache": {
@@ -5075,9 +5086,9 @@
       "integrity": "sha512-Hv9USGyH8EsPy0o8pPWE7x3YRIfuZDgMBirzjU6XLebhiSK2g53JlfqgolD0c39ne6wXAfaBNcIAvYe22Bav+Q==",
       "dev": true,
       "requires": {
-        "nanoassert": "1.1.0",
-        "nanotiming": "7.3.1",
-        "remove-array-items": "1.1.1"
+        "nanoassert": "^1.1.0",
+        "nanotiming": "^7.2.0",
+        "remove-array-items": "^1.0.0"
       }
     },
     "nanomatch": {
@@ -5086,17 +5097,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.3",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       }
     },
     "nanoscheduler": {
@@ -5105,7 +5116,7 @@
       "integrity": "sha512-jBbrF3qdU9321r8n9X7yu18DjP31Do2ItJm3mWrt90wJTrnDO+HXpoV7ftaUglAtjgj9s+OaCxGufbvx6pvbEQ==",
       "dev": true,
       "requires": {
-        "nanoassert": "1.1.0"
+        "nanoassert": "^1.1.0"
       }
     },
     "nanotiming": {
@@ -5114,8 +5125,8 @@
       "integrity": "sha512-l3lC7v/PfOuRWQa8vV29Jo6TG10wHtnthLElFXs4Te4Aas57Fo4n1Q8LH9n+NDh9riOzTVvb2QNBhTS4JUKNjw==",
       "dev": true,
       "requires": {
-        "nanoassert": "1.1.0",
-        "nanoscheduler": "1.0.3"
+        "nanoassert": "^1.1.0",
+        "nanoscheduler": "^1.0.2"
       }
     },
     "negotiator": {
@@ -5137,16 +5148,16 @@
       "dev": true
     },
     "nise": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",
-      "integrity": "sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "1.8.0",
-        "@sinonjs/fake-timers": "6.0.1",
-        "@sinonjs/text-encoding": "0.7.1",
-        "just-extend": "4.1.0",
-        "path-to-regexp": "1.8.0"
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
       }
     },
     "node-environment-flags": {
@@ -5155,8 +5166,8 @@
       "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
       "dev": true,
       "requires": {
-        "object.getownpropertydescriptors": "2.1.0",
-        "semver": "5.7.1"
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
       },
       "dependencies": {
         "semver": {
@@ -5173,18 +5184,18 @@
       "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
       "dev": true,
       "requires": {
-        "fstream": "1.0.12",
-        "glob": "7.1.6",
-        "graceful-fs": "4.2.4",
-        "mkdirp": "0.5.5",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.2",
-        "osenv": "0.1.5",
-        "request": "2.88.2",
-        "rimraf": "2.7.1",
-        "semver": "5.3.0",
-        "tar": "2.2.2",
-        "which": "1.3.1"
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
       },
       "dependencies": {
         "mkdirp": {
@@ -5193,7 +5204,7 @@
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "1.2.5"
+            "minimist": "^1.2.5"
           }
         },
         "nopt": {
@@ -5202,7 +5213,7 @@
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
-            "abbrev": "1.1.1"
+            "abbrev": "1"
           }
         },
         "semver": {
@@ -5225,23 +5236,23 @@
       "integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
       "dev": true,
       "requires": {
-        "async-foreach": "0.1.3",
-        "chalk": "1.1.3",
-        "cross-spawn": "3.0.1",
-        "gaze": "1.1.3",
-        "get-stdin": "4.0.1",
-        "glob": "7.1.6",
-        "in-publish": "2.0.1",
-        "lodash": "4.17.15",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.5",
-        "nan": "2.14.1",
-        "node-gyp": "3.8.0",
-        "npmlog": "4.1.2",
-        "request": "2.88.2",
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash": "^4.17.15",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.13.2",
+        "node-gyp": "^3.8.0",
+        "npmlog": "^4.0.0",
+        "request": "^2.88.0",
         "sass-graph": "2.2.5",
-        "stdout-stream": "1.4.1",
-        "true-case-path": "1.0.3"
+        "stdout-stream": "^1.4.0",
+        "true-case-path": "^1.0.2"
       },
       "dependencies": {
         "chalk": {
@@ -5250,11 +5261,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "mkdirp": {
@@ -5263,7 +5274,7 @@
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "1.2.5"
+            "minimist": "^1.2.5"
           }
         }
       }
@@ -5274,8 +5285,8 @@
       "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.1",
-        "osenv": "0.1.5"
+        "abbrev": "1",
+        "osenv": "^0.1.4"
       }
     },
     "normalize-package-data": {
@@ -5284,10 +5295,10 @@
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.8.8",
-        "resolve": "1.17.0",
-        "semver": "5.7.1",
-        "validate-npm-package-license": "3.0.4"
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       },
       "dependencies": {
         "semver": {
@@ -5316,7 +5327,7 @@
       "integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.2"
       }
     },
     "npmlog": {
@@ -5325,10 +5336,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.5",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "num2fraction": {
@@ -5349,10 +5360,10 @@
       "integrity": "sha512-LYlVuC1ZNSalQQkLNNPvcgPt2M9FTY9bs39mTCuFXtqh7jWbYzhDlmz2M6onPiXEhdZo+b9anRhc+uBGuJZ2bQ==",
       "dev": true,
       "requires": {
-        "a-sync-waterfall": "1.0.1",
-        "asap": "2.0.6",
-        "chokidar": "3.4.0",
-        "commander": "3.0.2"
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "chokidar": "^3.3.0",
+        "commander": "^3.0.2"
       },
       "dependencies": {
         "commander": {
@@ -5387,9 +5398,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -5398,7 +5409,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "kind-of": {
@@ -5407,15 +5418,15 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
     },
     "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
       "dev": true
     },
     "object-keys": {
@@ -5436,7 +5447,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.assign": {
@@ -5445,10 +5456,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.1",
-        "object-keys": "1.1.1"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.getownpropertydescriptors": {
@@ -5457,8 +5468,8 @@
       "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "object.pick": {
@@ -5467,7 +5478,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "on-finished": {
@@ -5485,7 +5496,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "openurl": {
@@ -5500,7 +5511,7 @@
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "dev": true,
       "requires": {
-        "is-wsl": "1.1.0"
+        "is-wsl": "^1.1.0"
       }
     },
     "ordered-read-streams": {
@@ -5509,7 +5520,7 @@
       "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.7"
+        "readable-stream": "^2.0.1"
       }
     },
     "os-homedir": {
@@ -5524,7 +5535,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "1.0.0"
+        "lcid": "^1.0.0"
       }
     },
     "os-tmpdir": {
@@ -5539,8 +5550,8 @@
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "p-limit": {
@@ -5549,7 +5560,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -5558,7 +5569,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.3.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-try": {
@@ -5573,9 +5584,9 @@
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "dev": true,
       "requires": {
-        "is-absolute": "1.0.0",
-        "map-cache": "0.2.2",
-        "path-root": "0.1.1"
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
       }
     },
     "parse-json": {
@@ -5584,7 +5595,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-ms": {
@@ -5605,7 +5616,7 @@
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseuri": {
@@ -5614,7 +5625,7 @@
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseurl": {
@@ -5641,7 +5652,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -5668,7 +5679,7 @@
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
-        "path-root-regex": "0.1.2"
+        "path-root-regex": "^0.1.0"
       }
     },
     "path-root-regex": {
@@ -5700,9 +5711,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.4",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "pathval": {
@@ -5741,7 +5752,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -5750,7 +5761,7 @@
       "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
       "dev": true,
       "requires": {
-        "find-up": "3.0.0"
+        "find-up": "^3.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -5759,7 +5770,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "3.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "locate-path": {
@@ -5768,8 +5779,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "3.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "p-limit": {
@@ -5778,7 +5789,7 @@
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
-            "p-try": "2.2.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
@@ -5787,7 +5798,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "2.3.0"
+            "p-limit": "^2.0.0"
           }
         },
         "p-try": {
@@ -5810,7 +5821,7 @@
       "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -5819,7 +5830,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         }
       }
@@ -5830,7 +5841,7 @@
       "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
       "dev": true,
       "requires": {
-        "semver-compare": "1.0.0"
+        "semver-compare": "^1.0.0"
       }
     },
     "plugin-error": {
@@ -5839,10 +5850,10 @@
       "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
       "dev": true,
       "requires": {
-        "ansi-colors": "1.1.0",
-        "arr-diff": "4.0.0",
-        "arr-union": "3.1.0",
-        "extend-shallow": "3.0.2"
+        "ansi-colors": "^1.0.1",
+        "arr-diff": "^4.0.0",
+        "arr-union": "^3.1.0",
+        "extend-shallow": "^3.0.2"
       }
     },
     "portscanner": {
@@ -5852,7 +5863,7 @@
       "dev": true,
       "requires": {
         "async": "1.5.2",
-        "is-number-like": "1.0.8"
+        "is-number-like": "^1.0.3"
       }
     },
     "posix-character-classes": {
@@ -5867,9 +5878,9 @@
       "integrity": "sha512-a937VDHE1ftkjk+8/7nj/mrjtmkn69xxzJgRETXdAUU+IgOYPQNJF17haGWbeDxSyk++HA14UA98FurvPyBJOA==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "source-map": "0.6.1",
-        "supports-color": "6.1.0"
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5878,7 +5889,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5887,9 +5898,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           },
           "dependencies": {
             "supports-color": {
@@ -5898,7 +5909,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
               }
             }
           }
@@ -5936,7 +5947,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5953,9 +5964,9 @@
       "integrity": "sha1-rbx5YLe7/iiaVX3F9zdhmiINBqU=",
       "dev": true,
       "requires": {
-        "condense-newlines": "0.2.1",
-        "extend-shallow": "2.0.1",
-        "js-beautify": "1.11.0"
+        "condense-newlines": "^0.2.1",
+        "extend-shallow": "^2.0.1",
+        "js-beautify": "^1.6.12"
       },
       "dependencies": {
         "extend-shallow": {
@@ -5964,7 +5975,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -5975,7 +5986,7 @@
       "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
       "dev": true,
       "requires": {
-        "parse-ms": "0.1.2"
+        "parse-ms": "^0.1.0"
       }
     },
     "process-nextick-args": {
@@ -5990,7 +6001,7 @@
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "proto-list": {
@@ -6023,14 +6034,14 @@
       "integrity": "sha512-XhoaDlvi6NIzL49nu094R2NA6P37ijtgMDuWE+ofekDChvfKnzFal60bhSdiy8y2PBO6fmz3oMEIcfpBVRUdvw==",
       "dev": true,
       "requires": {
-        "pug-code-gen": "2.0.2",
-        "pug-filters": "3.1.1",
-        "pug-lexer": "4.1.0",
-        "pug-linker": "3.0.6",
-        "pug-load": "2.0.12",
-        "pug-parser": "5.0.1",
-        "pug-runtime": "2.0.5",
-        "pug-strip-comments": "1.0.4"
+        "pug-code-gen": "^2.0.2",
+        "pug-filters": "^3.1.1",
+        "pug-lexer": "^4.1.0",
+        "pug-linker": "^3.0.6",
+        "pug-load": "^2.0.12",
+        "pug-parser": "^5.0.1",
+        "pug-runtime": "^2.0.5",
+        "pug-strip-comments": "^1.0.4"
       }
     },
     "pug-attrs": {
@@ -6039,9 +6050,9 @@
       "integrity": "sha512-TaZ4Z2TWUPDJcV3wjU3RtUXMrd3kM4Wzjbe3EWnSsZPsJ3LDI0F3yCnf2/W7PPFF+edUFQ0HgDL1IoxSz5K8EQ==",
       "dev": true,
       "requires": {
-        "constantinople": "3.1.2",
-        "js-stringify": "1.0.2",
-        "pug-runtime": "2.0.5"
+        "constantinople": "^3.0.1",
+        "js-stringify": "^1.0.1",
+        "pug-runtime": "^2.0.5"
       }
     },
     "pug-code-gen": {
@@ -6050,14 +6061,14 @@
       "integrity": "sha512-kROFWv/AHx/9CRgoGJeRSm+4mLWchbgpRzTEn8XCiwwOy6Vh0gAClS8Vh5TEJ9DBjaP8wCjS3J6HKsEsYdvaCw==",
       "dev": true,
       "requires": {
-        "constantinople": "3.1.2",
-        "doctypes": "1.1.0",
-        "js-stringify": "1.0.2",
-        "pug-attrs": "2.0.4",
-        "pug-error": "1.3.3",
-        "pug-runtime": "2.0.5",
-        "void-elements": "2.0.1",
-        "with": "5.1.1"
+        "constantinople": "^3.1.2",
+        "doctypes": "^1.1.0",
+        "js-stringify": "^1.0.1",
+        "pug-attrs": "^2.0.4",
+        "pug-error": "^1.3.3",
+        "pug-runtime": "^2.0.5",
+        "void-elements": "^2.0.1",
+        "with": "^5.0.0"
       }
     },
     "pug-error": {
@@ -6072,13 +6083,13 @@
       "integrity": "sha512-lFfjNyGEyVWC4BwX0WyvkoWLapI5xHSM3xZJFUhx4JM4XyyRdO8Aucc6pCygnqV2uSgJFaJWW3Ft1wCWSoQkQg==",
       "dev": true,
       "requires": {
-        "clean-css": "4.2.3",
-        "constantinople": "3.1.2",
+        "clean-css": "^4.1.11",
+        "constantinople": "^3.0.1",
         "jstransformer": "1.0.0",
-        "pug-error": "1.3.3",
-        "pug-walk": "1.1.8",
-        "resolve": "1.17.0",
-        "uglify-js": "2.8.29"
+        "pug-error": "^1.3.3",
+        "pug-walk": "^1.1.8",
+        "resolve": "^1.1.6",
+        "uglify-js": "^2.6.1"
       },
       "dependencies": {
         "camelcase": {
@@ -6093,8 +6104,8 @@
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           }
         },
@@ -6104,9 +6115,9 @@
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           }
         },
         "window-size": {
@@ -6127,9 +6138,9 @@
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -6141,9 +6152,9 @@
       "integrity": "sha512-i55yzEBtjm0mlplW4LoANq7k3S8gDdfC6+LThGEvsK4FuobcKfDAwt6V4jKPH9RtiE3a2Akfg5UpafZ1OksaPA==",
       "dev": true,
       "requires": {
-        "character-parser": "2.2.0",
-        "is-expression": "3.0.0",
-        "pug-error": "1.3.3"
+        "character-parser": "^2.1.1",
+        "is-expression": "^3.0.0",
+        "pug-error": "^1.3.3"
       }
     },
     "pug-linker": {
@@ -6152,8 +6163,8 @@
       "integrity": "sha512-bagfuHttfQOpANGy1Y6NJ+0mNb7dD2MswFG2ZKj22s8g0wVsojpRlqveEQHmgXXcfROB2RT6oqbPYr9EN2ZWzg==",
       "dev": true,
       "requires": {
-        "pug-error": "1.3.3",
-        "pug-walk": "1.1.8"
+        "pug-error": "^1.3.3",
+        "pug-walk": "^1.1.8"
       }
     },
     "pug-load": {
@@ -6162,8 +6173,8 @@
       "integrity": "sha512-UqpgGpyyXRYgJs/X60sE6SIf8UBsmcHYKNaOccyVLEuT6OPBIMo6xMPhoJnqtB3Q3BbO4Z3Bjz5qDsUWh4rXsg==",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "pug-walk": "1.1.8"
+        "object-assign": "^4.1.0",
+        "pug-walk": "^1.1.8"
       }
     },
     "pug-parser": {
@@ -6172,7 +6183,7 @@
       "integrity": "sha512-nGHqK+w07p5/PsPIyzkTQfzlYfuqoiGjaoqHv1LjOv2ZLXmGX1O+4Vcvps+P4LhxZ3drYSljjq4b+Naid126wA==",
       "dev": true,
       "requires": {
-        "pug-error": "1.3.3",
+        "pug-error": "^1.3.3",
         "token-stream": "0.0.1"
       }
     },
@@ -6188,7 +6199,7 @@
       "integrity": "sha512-i5j/9CS4yFhSxHp5iKPHwigaig/VV9g+FgReLJWWHEHbvKsbqL0oP/K5ubuLco6Wu3Kan5p7u7qk8A4oLLh6vw==",
       "dev": true,
       "requires": {
-        "pug-error": "1.3.3"
+        "pug-error": "^1.3.3"
       }
     },
     "pug-walk": {
@@ -6203,8 +6214,8 @@
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.4",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -6213,9 +6224,9 @@
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
-        "duplexify": "3.7.1",
-        "inherits": "2.0.4",
-        "pump": "2.0.1"
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       },
       "dependencies": {
         "duplexify": {
@@ -6224,10 +6235,10 @@
           "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.4",
-            "inherits": "2.0.4",
-            "readable-stream": "2.3.7",
-            "stream-shift": "1.0.1"
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
           }
         }
       }
@@ -6274,9 +6285,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.5.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -6285,8 +6296,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -6295,13 +6306,13 @@
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.4",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.1",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -6318,9 +6329,9 @@
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.4",
-        "micromatch": "3.1.10",
-        "readable-stream": "2.3.7"
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
       }
     },
     "recursive-copy": {
@@ -6329,16 +6340,16 @@
       "integrity": "sha512-S9J9XJUnfZ2NUS3lK6lx6HWLl2nWui+f7AKuu+qoFs4ikEPYgZ3qKk1T6tmBnr7PzhtKnawE+6TREy9XQKmxCA==",
       "dev": true,
       "requires": {
-        "del": "2.2.2",
+        "del": "^2.2.0",
         "emitter-mixin": "0.0.3",
-        "errno": "0.1.7",
-        "graceful-fs": "4.2.4",
-        "junk": "1.0.3",
-        "maximatch": "0.1.0",
-        "mkdirp": "0.5.5",
-        "pify": "2.3.0",
-        "promise": "7.3.1",
-        "slash": "1.0.0"
+        "errno": "^0.1.2",
+        "graceful-fs": "^4.1.4",
+        "junk": "^1.0.1",
+        "maximatch": "^0.1.0",
+        "mkdirp": "^0.5.1",
+        "pify": "^2.3.0",
+        "promise": "^7.0.1",
+        "slash": "^1.0.0"
       },
       "dependencies": {
         "mkdirp": {
@@ -6347,7 +6358,7 @@
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "1.2.5"
+            "minimist": "^1.2.5"
           }
         }
       }
@@ -6358,8 +6369,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "regenerator-runtime": {
@@ -6374,8 +6385,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "remove-array-items": {
@@ -6390,8 +6401,8 @@
       "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6",
-        "is-utf8": "0.2.1"
+        "is-buffer": "^1.1.5",
+        "is-utf8": "^0.2.1"
       }
     },
     "remove-bom-stream": {
@@ -6400,9 +6411,9 @@
       "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
       "dev": true,
       "requires": {
-        "remove-bom-buffer": "3.0.0",
-        "safe-buffer": "5.1.2",
-        "through2": "2.0.5"
+        "remove-bom-buffer": "^3.0.0",
+        "safe-buffer": "^5.1.0",
+        "through2": "^2.0.3"
       },
       "dependencies": {
         "through2": {
@@ -6411,8 +6422,8 @@
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.7",
-            "xtend": "4.0.2"
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -6441,7 +6452,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.1.0"
+        "is-finite": "^1.0.0"
       }
     },
     "replace-ext": {
@@ -6456,26 +6467,26 @@
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.10.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.8",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.3",
-        "har-validator": "5.1.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.27",
-        "oauth-sign": "0.9.0",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.5.0",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.4.0"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       },
       "dependencies": {
         "qs": {
@@ -6510,7 +6521,7 @@
       "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-cwd": {
@@ -6519,7 +6530,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       }
     },
     "resolve-from": {
@@ -6534,7 +6545,7 @@
       "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
       "dev": true,
       "requires": {
-        "value-or-function": "3.0.0"
+        "value-or-function": "^3.0.0"
       }
     },
     "resolve-url": {
@@ -6549,8 +6560,8 @@
       "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "minimatch": "3.0.4"
+        "debug": "^2.2.0",
+        "minimatch": "^3.0.2"
       },
       "dependencies": {
         "debug": {
@@ -6588,7 +6599,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -6597,7 +6608,7 @@
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.6"
+        "glob": "^7.1.3"
       }
     },
     "run-parallel": {
@@ -6633,7 +6644,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
@@ -6648,10 +6659,10 @@
       "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
       "dev": true,
       "requires": {
-        "glob": "7.1.6",
-        "lodash": "4.17.15",
-        "scss-tokenizer": "0.2.3",
-        "yargs": "13.3.2"
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^13.3.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6666,7 +6677,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "camelcase": {
@@ -6681,9 +6692,9 @@
           "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
-            "string-width": "3.1.0",
-            "strip-ansi": "5.2.0",
-            "wrap-ansi": "5.1.0"
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
           }
         },
         "color-convert": {
@@ -6707,7 +6718,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "3.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "get-caller-file": {
@@ -6728,8 +6739,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "3.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "p-limit": {
@@ -6738,7 +6749,7 @@
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
-            "p-try": "2.2.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
@@ -6747,7 +6758,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "2.3.0"
+            "p-limit": "^2.0.0"
           }
         },
         "p-try": {
@@ -6774,9 +6785,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -6785,7 +6796,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         },
         "which-module": {
@@ -6800,9 +6811,9 @@
           "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "string-width": "3.1.0",
-            "strip-ansi": "5.2.0"
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
           }
         },
         "y18n": {
@@ -6817,16 +6828,16 @@
           "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
           "dev": true,
           "requires": {
-            "cliui": "5.0.0",
-            "find-up": "3.0.0",
-            "get-caller-file": "2.0.5",
-            "require-directory": "2.1.1",
-            "require-main-filename": "2.0.0",
-            "set-blocking": "2.0.0",
-            "string-width": "3.1.0",
-            "which-module": "2.0.0",
-            "y18n": "4.0.0",
-            "yargs-parser": "13.1.2"
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
           }
         },
         "yargs-parser": {
@@ -6835,8 +6846,8 @@
           "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
           "dev": true,
           "requires": {
-            "camelcase": "5.3.1",
-            "decamelize": "1.2.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -6847,8 +6858,8 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.5.2",
-        "source-map": "0.4.4"
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
       },
       "dependencies": {
         "source-map": {
@@ -6857,7 +6868,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -6868,8 +6879,8 @@
       "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "kind-of": "6.0.3"
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -6878,7 +6889,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -6902,18 +6913,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.1",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       },
       "dependencies": {
         "debug": {
@@ -6931,10 +6942,10 @@
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
-            "depd": "1.1.2",
+            "depd": "~1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": "1.4.0"
+            "statuses": ">= 1.4.0 < 2"
           }
         },
         "inherits": {
@@ -6969,13 +6980,13 @@
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.7",
+        "accepts": "~1.3.4",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "1.0.3",
-        "http-errors": "1.6.3",
-        "mime-types": "2.1.27",
-        "parseurl": "1.3.3"
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
       },
       "dependencies": {
         "debug": {
@@ -6993,10 +7004,10 @@
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
-            "depd": "1.1.2",
+            "depd": "~1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": "1.5.0"
+            "statuses": ">= 1.4.0 < 2"
           }
         },
         "inherits": {
@@ -7031,9 +7042,9 @@
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.3",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -7055,10 +7066,10 @@
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -7067,7 +7078,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -7096,13 +7107,13 @@
       "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "1.8.0",
-        "@sinonjs/fake-timers": "6.0.1",
-        "@sinonjs/formatio": "5.0.1",
-        "@sinonjs/samsam": "5.0.3",
-        "diff": "4.0.2",
-        "nise": "4.0.3",
-        "supports-color": "7.1.0"
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.0.3",
+        "diff": "^4.0.2",
+        "nise": "^4.0.1",
+        "supports-color": "^7.1.0"
       },
       "dependencies": {
         "diff": {
@@ -7117,7 +7128,7 @@
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
-            "has-flag": "4.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -7140,14 +7151,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.3",
-        "use": "3.1.1"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -7165,7 +7176,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -7174,7 +7185,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "ms": {
@@ -7191,9 +7202,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -7202,7 +7213,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -7211,7 +7222,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -7220,7 +7231,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -7229,9 +7240,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.3"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -7242,7 +7253,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       },
       "dependencies": {
         "kind-of": {
@@ -7251,7 +7262,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -7262,12 +7273,12 @@
       "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
       "dev": true,
       "requires": {
-        "debug": "3.1.0",
-        "engine.io": "3.2.1",
-        "has-binary2": "1.0.3",
-        "socket.io-adapter": "1.1.2",
+        "debug": "~3.1.0",
+        "engine.io": "~3.2.0",
+        "has-binary2": "~1.0.2",
+        "socket.io-adapter": "~1.1.0",
         "socket.io-client": "2.1.1",
-        "socket.io-parser": "3.2.0"
+        "socket.io-parser": "~3.2.0"
       },
       "dependencies": {
         "debug": {
@@ -7287,14 +7298,14 @@
           "requires": {
             "component-emitter": "1.2.1",
             "component-inherit": "0.0.3",
-            "debug": "3.1.0",
-            "engine.io-parser": "2.1.3",
+            "debug": "~3.1.0",
+            "engine.io-parser": "~2.1.1",
             "has-cors": "1.1.0",
             "indexof": "0.0.1",
             "parseqs": "0.0.5",
             "parseuri": "0.0.5",
-            "ws": "3.3.3",
-            "xmlhttprequest-ssl": "1.5.5",
+            "ws": "~3.3.1",
+            "xmlhttprequest-ssl": "~1.5.4",
             "yeast": "0.1.2"
           }
         },
@@ -7305,10 +7316,10 @@
           "dev": true,
           "requires": {
             "after": "0.8.2",
-            "arraybuffer.slice": "0.0.7",
+            "arraybuffer.slice": "~0.0.7",
             "base64-arraybuffer": "0.1.5",
             "blob": "0.0.5",
-            "has-binary2": "1.0.3"
+            "has-binary2": "~1.0.2"
           }
         },
         "ms": {
@@ -7327,15 +7338,15 @@
             "base64-arraybuffer": "0.1.5",
             "component-bind": "1.0.0",
             "component-emitter": "1.2.1",
-            "debug": "3.1.0",
-            "engine.io-client": "3.2.1",
-            "has-binary2": "1.0.3",
+            "debug": "~3.1.0",
+            "engine.io-client": "~3.2.0",
+            "has-binary2": "~1.0.2",
             "has-cors": "1.1.0",
             "indexof": "0.0.1",
             "object-component": "0.0.3",
             "parseqs": "0.0.5",
             "parseuri": "0.0.5",
-            "socket.io-parser": "3.2.0",
+            "socket.io-parser": "~3.2.0",
             "to-array": "0.1.4"
           }
         },
@@ -7346,7 +7357,7 @@
           "dev": true,
           "requires": {
             "component-emitter": "1.2.1",
-            "debug": "3.1.0",
+            "debug": "~3.1.0",
             "isarray": "2.0.1"
           }
         },
@@ -7356,9 +7367,9 @@
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "dev": true,
           "requires": {
-            "async-limiter": "1.0.1",
-            "safe-buffer": "5.1.2",
-            "ultron": "1.1.1"
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
           }
         }
       }
@@ -7379,15 +7390,15 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "4.1.1",
-        "engine.io-client": "3.4.2",
-        "has-binary2": "1.0.3",
+        "debug": "~4.1.0",
+        "engine.io-client": "~3.4.0",
+        "has-binary2": "~1.0.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "3.3.0",
+        "socket.io-parser": "~3.3.0",
         "to-array": "0.1.4"
       }
     },
@@ -7398,7 +7409,7 @@
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "3.1.0",
+        "debug": "~3.1.0",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -7431,11 +7442,11 @@
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "dev": true,
       "requires": {
-        "atob": "2.1.2",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-url": {
@@ -7450,8 +7461,8 @@
       "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.1",
-        "spdx-license-ids": "3.0.5"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -7466,8 +7477,8 @@
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.3.0",
-        "spdx-license-ids": "3.0.5"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -7482,7 +7493,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "sprintf-js": {
@@ -7497,15 +7508,15 @@
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "static-extend": {
@@ -7514,8 +7525,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -7524,7 +7535,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -7541,7 +7552,7 @@
       "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.7"
+        "readable-stream": "^2.0.1"
       }
     },
     "stream-shift": {
@@ -7556,8 +7567,8 @@
       "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
       "dev": true,
       "requires": {
-        "commander": "2.20.3",
-        "limiter": "1.1.5"
+        "commander": "^2.2.0",
+        "limiter": "^1.0.5"
       }
     },
     "string-width": {
@@ -7566,9 +7577,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string.prototype.trimend": {
@@ -7577,30 +7588,8 @@
       "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5"
-      }
-    },
-    "string.prototype.trimleft": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5",
-        "string.prototype.trimstart": "1.0.1"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5",
-        "string.prototype.trimend": "1.0.1"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "string.prototype.trimstart": {
@@ -7609,8 +7598,8 @@
       "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "string_decoder": {
@@ -7619,7 +7608,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -7628,7 +7617,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -7637,7 +7626,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-bom-string": {
@@ -7652,7 +7641,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -7679,9 +7668,9 @@
       "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.12",
-        "inherits": "2.0.4"
+        "block-stream": "*",
+        "fstream": "^1.0.12",
+        "inherits": "2"
       }
     },
     "ternary-stream": {
@@ -7690,10 +7679,10 @@
       "integrity": "sha512-oIzdi+UL/JdktkT+7KU5tSIQjj8pbShj3OASuvDEhm0NT5lppsm7aXWAmAq4/QMaBIyfuEcNLbAQA+HpaISobQ==",
       "dev": true,
       "requires": {
-        "duplexify": "4.1.1",
-        "fork-stream": "0.0.4",
-        "merge-stream": "2.0.0",
-        "through2": "3.0.1"
+        "duplexify": "^4.1.1",
+        "fork-stream": "^0.0.4",
+        "merge-stream": "^2.0.0",
+        "through2": "^3.0.1"
       }
     },
     "text-table": {
@@ -7708,8 +7697,8 @@
       "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "object-path": "0.9.2"
+        "chalk": "^1.1.1",
+        "object-path": "^0.9.0"
       },
       "dependencies": {
         "chalk": {
@@ -7718,11 +7707,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         }
       }
@@ -7733,7 +7722,7 @@
       "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.7"
+        "readable-stream": "2 || 3"
       }
     },
     "through2-filter": {
@@ -7742,8 +7731,8 @@
       "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
       "dev": true,
       "requires": {
-        "through2": "2.0.5",
-        "xtend": "4.0.2"
+        "through2": "~2.0.0",
+        "xtend": "~4.0.0"
       },
       "dependencies": {
         "through2": {
@@ -7752,8 +7741,8 @@
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.7",
-            "xtend": "4.0.2"
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -7764,10 +7753,10 @@
       "integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
       "dev": true,
       "requires": {
-        "chalk": "0.4.0",
-        "date-time": "0.1.1",
-        "pretty-ms": "0.2.2",
-        "text-table": "0.2.0"
+        "chalk": "^0.4.0",
+        "date-time": "^0.1.1",
+        "pretty-ms": "^0.2.1",
+        "text-table": "^0.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7782,9 +7771,9 @@
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
+            "ansi-styles": "~1.0.0",
+            "has-color": "~0.1.0",
+            "strip-ansi": "~0.1.0"
           }
         },
         "strip-ansi": {
@@ -7807,8 +7796,8 @@
       "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.53",
-        "next-tick": "1.1.0"
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
       }
     },
     "to-absolute-glob": {
@@ -7817,8 +7806,8 @@
       "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
       "dev": true,
       "requires": {
-        "is-absolute": "1.0.0",
-        "is-negated-glob": "1.0.0"
+        "is-absolute": "^1.0.0",
+        "is-negated-glob": "^1.0.0"
       }
     },
     "to-array": {
@@ -7839,7 +7828,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -7848,7 +7837,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -7859,10 +7848,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -7871,8 +7860,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "to-through": {
@@ -7881,7 +7870,7 @@
       "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
       "dev": true,
       "requires": {
-        "through2": "2.0.5"
+        "through2": "^2.0.3"
       },
       "dependencies": {
         "through2": {
@@ -7890,8 +7879,8 @@
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.7",
-            "xtend": "4.0.2"
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -7914,8 +7903,8 @@
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
       "requires": {
-        "psl": "1.8.0",
-        "punycode": "2.1.1"
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "trim-newlines": {
@@ -7930,7 +7919,7 @@
       "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
       "dev": true,
       "requires": {
-        "glob": "7.1.6"
+        "glob": "^7.1.2"
       }
     },
     "tunnel-agent": {
@@ -7939,7 +7928,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -7978,7 +7967,7 @@
       "integrity": "sha512-8RZBJq5smLOa7KslsNsVcSH+KOXf1uDU8yqLeNuVKwmT0T3FA0ZoXlinQfRad7SDcbZZRZE4ov+2v71EnxNyCA==",
       "dev": true,
       "requires": {
-        "commander": "2.20.3"
+        "commander": "~2.20.3"
       }
     },
     "uglify-to-browserify": {
@@ -8006,10 +7995,10 @@
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "2.0.1"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
       }
     },
     "unique-stream": {
@@ -8018,8 +8007,8 @@
       "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
       "dev": true,
       "requires": {
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "through2-filter": "3.0.0"
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "through2-filter": "^3.0.0"
       }
     },
     "universalify": {
@@ -8040,8 +8029,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -8050,9 +8039,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -8092,7 +8081,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "urix": {
@@ -8137,8 +8126,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.1.1",
-        "spdx-expression-parse": "3.0.1"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "value-or-function": {
@@ -8153,9 +8142,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vinyl": {
@@ -8164,12 +8153,12 @@
       "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
       "dev": true,
       "requires": {
-        "clone": "2.1.2",
-        "clone-buffer": "1.0.0",
-        "clone-stats": "1.0.0",
-        "cloneable-readable": "1.1.3",
-        "remove-trailing-separator": "1.1.0",
-        "replace-ext": "1.0.1"
+        "clone": "^2.1.1",
+        "clone-buffer": "^1.0.0",
+        "clone-stats": "^1.0.0",
+        "cloneable-readable": "^1.0.0",
+        "remove-trailing-separator": "^1.0.1",
+        "replace-ext": "^1.0.0"
       }
     },
     "vinyl-fs": {
@@ -8178,23 +8167,23 @@
       "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
       "dev": true,
       "requires": {
-        "fs-mkdirp-stream": "1.0.0",
-        "glob-stream": "6.1.0",
-        "graceful-fs": "4.2.4",
-        "is-valid-glob": "1.0.0",
-        "lazystream": "1.0.0",
-        "lead": "1.0.0",
-        "object.assign": "4.1.0",
-        "pumpify": "1.5.1",
-        "readable-stream": "2.3.7",
-        "remove-bom-buffer": "3.0.0",
-        "remove-bom-stream": "1.2.0",
-        "resolve-options": "1.1.0",
-        "through2": "2.0.5",
-        "to-through": "2.0.0",
-        "value-or-function": "3.0.0",
-        "vinyl": "2.2.0",
-        "vinyl-sourcemap": "1.1.0"
+        "fs-mkdirp-stream": "^1.0.0",
+        "glob-stream": "^6.1.0",
+        "graceful-fs": "^4.0.0",
+        "is-valid-glob": "^1.0.0",
+        "lazystream": "^1.0.0",
+        "lead": "^1.0.0",
+        "object.assign": "^4.0.4",
+        "pumpify": "^1.3.5",
+        "readable-stream": "^2.3.3",
+        "remove-bom-buffer": "^3.0.0",
+        "remove-bom-stream": "^1.2.0",
+        "resolve-options": "^1.1.0",
+        "through2": "^2.0.0",
+        "to-through": "^2.0.0",
+        "value-or-function": "^3.0.0",
+        "vinyl": "^2.0.0",
+        "vinyl-sourcemap": "^1.1.0"
       },
       "dependencies": {
         "through2": {
@@ -8203,8 +8192,8 @@
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.7",
-            "xtend": "4.0.2"
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -8215,13 +8204,13 @@
       "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
       "dev": true,
       "requires": {
-        "append-buffer": "1.0.2",
-        "convert-source-map": "1.7.0",
-        "graceful-fs": "4.2.4",
-        "normalize-path": "2.1.1",
-        "now-and-later": "2.0.1",
-        "remove-bom-buffer": "3.0.0",
-        "vinyl": "2.2.0"
+        "append-buffer": "^1.0.2",
+        "convert-source-map": "^1.5.0",
+        "graceful-fs": "^4.1.6",
+        "normalize-path": "^2.1.1",
+        "now-and-later": "^2.0.0",
+        "remove-bom-buffer": "^3.0.0",
+        "vinyl": "^2.0.0"
       },
       "dependencies": {
         "normalize-path": {
@@ -8230,7 +8219,7 @@
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "1.1.0"
+            "remove-trailing-separator": "^1.0.1"
           }
         }
       }
@@ -8241,7 +8230,7 @@
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.1"
       }
     },
     "void-elements": {
@@ -8256,7 +8245,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -8271,7 +8260,7 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2 || 2"
       }
     },
     "window-size": {
@@ -8286,8 +8275,8 @@
       "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0",
-        "acorn-globals": "3.1.0"
+        "acorn": "^3.1.0",
+        "acorn-globals": "^3.0.0"
       }
     },
     "wordwrap": {
@@ -8302,8 +8291,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -8318,7 +8307,7 @@
       "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
       "dev": true,
       "requires": {
-        "async-limiter": "1.0.1"
+        "async-limiter": "~1.0.0"
       }
     },
     "xmlhttprequest-ssl": {
@@ -8351,20 +8340,20 @@
       "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.3",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "window-size": "0.2.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "4.2.1"
+        "camelcase": "^3.0.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^1.4.0",
+        "read-pkg-up": "^1.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^1.0.2",
+        "which-module": "^1.0.0",
+        "window-size": "^0.2.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^4.1.0"
       }
     },
     "yargs-parser": {
@@ -8373,7 +8362,7 @@
       "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0"
+        "camelcase": "^3.0.0"
       }
     },
     "yargs-unparser": {
@@ -8382,9 +8371,9 @@
       "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
       "dev": true,
       "requires": {
-        "flat": "4.1.0",
-        "lodash": "4.17.15",
-        "yargs": "13.3.2"
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8399,7 +8388,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "camelcase": {
@@ -8414,9 +8403,9 @@
           "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
-            "string-width": "3.1.0",
-            "strip-ansi": "5.2.0",
-            "wrap-ansi": "5.1.0"
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
           }
         },
         "color-convert": {
@@ -8440,7 +8429,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "3.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "get-caller-file": {
@@ -8461,8 +8450,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "3.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "p-limit": {
@@ -8471,7 +8460,7 @@
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
-            "p-try": "2.2.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
@@ -8480,7 +8469,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "2.3.0"
+            "p-limit": "^2.0.0"
           }
         },
         "p-try": {
@@ -8507,9 +8496,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -8518,7 +8507,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         },
         "which-module": {
@@ -8533,9 +8522,9 @@
           "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "string-width": "3.1.0",
-            "strip-ansi": "5.2.0"
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
           }
         },
         "y18n": {
@@ -8550,16 +8539,16 @@
           "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
           "dev": true,
           "requires": {
-            "cliui": "5.0.0",
-            "find-up": "3.0.0",
-            "get-caller-file": "2.0.5",
-            "require-directory": "2.1.1",
-            "require-main-filename": "2.0.0",
-            "set-blocking": "2.0.0",
-            "string-width": "3.1.0",
-            "which-module": "2.0.0",
-            "y18n": "4.0.0",
-            "yargs-parser": "13.1.2"
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
           }
         },
         "yargs-parser": {
@@ -8568,8 +8557,8 @@
           "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
           "dev": true,
           "requires": {
-            "camelcase": "5.3.1",
-            "decamelize": "1.2.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "chai": "^4.2.0",
     "eleventy-plugin-sass": "^1.0.0",
     "fs-extra": "^9.0.0",
-    "mocha": "^7.1.1",
+    "mocha": "^7.2.0",
     "mocha-chrome": "^2.2.0",
     "sinon": "^9.0.2",
     "uglify-js": "^3.9.1"

--- a/src/_hyperscript.ts
+++ b/src/_hyperscript.ts
@@ -390,7 +390,7 @@
                     return contextLine + "\n" + " ".repeat(offset) + "^^\n\n";
                 }
 
-                function raiseParseError(tokens, message) {
+                function raiseParseError(tokens:any, message?:string) {
                     message = (message || "Unexpected Token : " + tokens.currentToken().value) + "\n\n" +
                         createParserContext(tokens);
                     var error = new Error(message);
@@ -861,7 +861,7 @@
 
             _parser.addGrammarElement("arrayLiteral", function (parser, tokens) {
                 if (tokens.matchOpToken('[')) {
-                    var values = [];
+                    var values:any[] = [];
                     if (!tokens.matchOpToken(']')) {
                         do {
                             var expr = parser.parseElement("expression", tokens);
@@ -884,7 +884,7 @@
 
             _parser.addGrammarElement("blockLiteral", function (parser, tokens) {
                 if (tokens.matchOpToken('\\')) {
-                    var args = []
+                    var args:any[] = []
                     var arg1 = tokens.matchTokenType("IDENTIFIER");
                     if (arg1) {
                         args.push(arg1);
@@ -917,7 +917,7 @@
                 return parser.parseAnyOf(["parenthesized", "boolean", "null", "string", "number", "idRef", "classRef", "symbol", "propertyRef", "objectLiteral", "arrayLiteral", "blockLiteral"], tokens)
             });
 
-            _parser.addGrammarElement("propertyAccess", function (parser, tokens, root) {
+            _parser.addGrammarElement("propertyAccess", function (parser:Parser, tokens:Tokens, root) {
                 if (tokens.matchOpToken(".")) {
                     var prop = tokens.requireTokenType("IDENTIFIER");
                     var propertyAccess = {
@@ -934,7 +934,7 @@
 
             _parser.addGrammarElement("functionCall", function (parser, tokens, root) {
                 if (tokens.matchOpToken("(")) {
-                    var args = [];
+                    var args:any[] = [];
                     do {
                         args.push(parser.parseElement("expression", tokens));
                     } while (tokens.matchOpToken(","))
@@ -1150,7 +1150,7 @@
             })
 
             _parser.addGrammarElement("hyperscript", function (parser, tokens) {
-                var eventListeners = []
+                var eventListeners:any[] = []
                 do {
                     eventListeners.push(parser.parseElement("eventListener", tokens));
                 } while (tokens.matchToken("end") && tokens.hasMore())
@@ -1189,7 +1189,7 @@
                     var from = parser.parseElement("implicitMeTarget", tokens);
                 }
 
-                var args = [];
+                var args:any[] = [];
                 if (tokens.matchOpToken("(")) {
                     do {
                         args.push(tokens.requireTokenType('IDENTIFIER'));

--- a/src/_hyperscript.ts
+++ b/src/_hyperscript.ts
@@ -8,13 +8,13 @@
         root._hyperscript = factory();
     }
 }(typeof self !== 'undefined' ? self : this, function () {
-    return (function () {
+    return (function ():Hyperscript {
             'use strict';
 
             //-----------------------------------------------
             // Lexer
-            //-----------------------------------------------
-            var _lexer = function () {
+            //-----------------------------------------------            
+            var _lexer = function ():Lexer {
                 var OP_TABLE = {
                     '+': 'PLUS',
                     '-': 'MINUS',
@@ -46,37 +46,36 @@
                     '=': 'EQUALS'
                 };
 
-                function isValidCSSClassChar(c) {
+                function isValidCSSClassChar(c:string) {
                     return isAlpha(c) || isNumeric(c) || c === "-" || c === "_";
                 }
 
-                function isValidCSSIDChar(c) {
+                function isValidCSSIDChar(c:string) {
                     return isAlpha(c) || isNumeric(c) || c === "-" || c === "_" || c === ":";
                 }
 
-                function isWhitespace(c) {
+                function isWhitespace(c:string) {
                     return c === " " || c === "\t" || isNewline(c);
                 }
 
-                function positionString(token) {
+                function positionString(token:Token) {
                     return "[Line: " + token.line + ", Column: " + token.col + "]"
                 }
 
-                function isNewline(c) {
+                function isNewline(c:string) {
                     return c === '\r' || c === '\n';
                 }
 
-                function isNumeric(c) {
+                function isNumeric(c:string) {
                     return c >= '0' && c <= '9';
                 }
 
-                function isAlpha(c) {
+                function isAlpha(c:string) {
                     return (c >= 'a' && c <= 'z') ||
                         (c >= 'A' && c <= 'Z');
                 }
 
-
-                function makeTokensObject(tokens, consumed, source) {
+                function makeTokensObject(tokens:Token[], consumed, source): Tokens {
 
                     var ignoreWhiteSpace = true;
                     matchTokenType("WHITESPACE"); // consume any initial whitespace
@@ -119,13 +118,13 @@
                         }
                     }
 
-                    function matchTokenType(type1, type2, type3, type4) {
+                    function matchTokenType(type1?:string, type2?:string, type3?:string, type4?:string) {
                         if (currentToken() && currentToken().type && [type1, type2, type3, type4].indexOf(currentToken().type) >= 0) {
                             return consumeToken();
                         }
                     }
 
-                    function requireToken(value, type) {
+                    function requireToken(value, type:string) {
                         var token = matchToken(value, type);
                         if (token) {
                             return token;
@@ -134,14 +133,14 @@
                         }
                     }
 
-                    function matchToken(value, type) {
-                        var type = type || "IDENTIFIER";
-                        if (currentToken() && currentToken().value === value && currentToken().type === type) {
+                    function matchToken(value, type?:string) {
+                        var _type = type || "IDENTIFIER";
+                        if (currentToken() && currentToken().value === value && currentToken().type === _type) {
                             return consumeToken();
                         }
                     }
 
-                    function consumeToken() {
+                    function consumeToken():Token {
                         var match = tokens.shift();
                         consumed.push(match);
                         if(ignoreWhiteSpace) {
@@ -151,7 +150,7 @@
                     }
 
                     function consumeUntilWhitespace() {
-                        var tokenList = [];
+                        var tokenList:Token[] = [];
                         ignoreWhiteSpace = false;
                         while (currentToken() && currentToken().type !== "WHITESPACE") {
                             tokenList.push(consumeToken());
@@ -164,7 +163,7 @@
                         return tokens.length > 0;
                     }
 
-                    function currentToken() {
+                    function currentToken():Token {
                         return tokens[0];
                     }
 
@@ -185,7 +184,7 @@
                     }
                 }
 
-                function tokenize(string) {
+                function tokenize(string:string) {
                     var source = string;
                     var tokens = [];
                     var position = 0;
@@ -227,7 +226,7 @@
                         return token;
                     }
 
-                    function makeToken(type, value) {
+                    function makeToken(type:any, value?:any):Token {
                         return {
                             type: type,
                             value: value,
@@ -370,11 +369,11 @@
             //-----------------------------------------------
             // Parser
             //-----------------------------------------------
-            var _parser = function () {
+            var _parser = function ():Parser {
 
                 var GRAMMAR = {}
 
-                function addGrammarElement(name, definition) {
+                function addGrammarElement(name:string, definition:GrammarElement) {
                     GRAMMAR[name] = definition;
                 }
 
@@ -441,10 +440,10 @@
             //-----------------------------------------------
             // Runtime
             //-----------------------------------------------
-            var _runtime = function () {
+            var _runtime = function ():Runtime {
                 var SCRIPT_ATTRIBUTES = ["_", "script", "data-script"];
 
-                function matchesSelector(elt, selector) {
+                function matchesSelector(elt:Element, selector:string):boolean {
                     // noinspection JSUnresolvedVariable
                     var matchesFunction = elt.matches ||
                         elt.matchesSelector || elt.msMatchesSelector || elt.mozMatchesSelector
@@ -452,7 +451,7 @@
                     return matchesFunction && matchesFunction.call(elt, selector);
                 }
 
-                function makeEvent(eventName, detail) {
+                function makeEvent(eventName:string, detail):Event {
                     var evt;
                     if (window.CustomEvent && typeof window.CustomEvent === 'function') {
                         evt = new CustomEvent(eventName, {bubbles: true, cancelable: true, detail: detail});
@@ -463,7 +462,7 @@
                     return evt;
                 }
 
-                function triggerEvent(elt, eventName, detail) {
+                function triggerEvent(elt:Element, eventName:string, detail:Object):boolean {
                     var detail = detail || {};
                     detail["sentBy"] = elt;
                     var event = makeEvent(eventName, detail);
@@ -471,7 +470,7 @@
                     return eventResult;
                 }
 
-                function forEach(arr, func) {
+                function forEach(arr:any[], func) {
                     if (arr.length) {
                         for (var i = 0; i < arr.length; i++) {
                             func(arr[i]);
@@ -507,7 +506,7 @@
                     return last;
                 }
 
-                function getScript(elt) {
+                function getScript(elt:Element) {
                     for (var i = 0; i < SCRIPT_ATTRIBUTES.length; i++) {
                         var scriptAttribute = SCRIPT_ATTRIBUTES[i];
                         if (elt.hasAttribute && elt.hasAttribute(scriptAttribute)) {
@@ -517,13 +516,13 @@
                     return null;
                 }
 
-                function applyEventListeners(hypeScript, elt) {
+                function applyEventListeners(hypeScript, elt:Element) {
                     forEach(hypeScript.eventListeners, function (eventListener) {
                         eventListener(elt);
                     });
                 }
 
-                function setScriptAttrs(values) {
+                function setScriptAttrs(values:string[]) {
                     SCRIPT_ATTRIBUTES = values;
                 }
 
@@ -533,7 +532,7 @@
                     }).join(", ");
                 }
 
-                function isType(o, type) {
+                function isType(o:any, type:string) {
                     return Object.prototype.toString.call(o) === "[object " + type + "]";
                 }
 
@@ -560,7 +559,7 @@
                     return eval(evalString).apply(null, args);
                 }
 
-                function initElement(elt) {
+                function initElement(elt:Element) {
                     var src = getScript(elt);
                     if (src) {
                         var tokens = _lexer.tokenize(src);
@@ -574,7 +573,7 @@
                     }
                 }
 
-                function ajax(method, url, callback, data) {
+                function ajax(method:string, url:string, callback, data) {
                     var xhr = new XMLHttpRequest();
                     xhr.onload = function() {
                         callback(this.response, xhr);
@@ -583,7 +582,7 @@
                     xhr.send(JSON.stringify(data));
                 }
 
-                function typeCheck(value, typeString, nullOk) {
+                function typeCheck(value:any, typeString:string, nullOk:boolean) {
                     if (value == null && nullOk) {
                         return value;
                     }
@@ -1660,11 +1659,11 @@
                 return true;
             }
 
-            function init(elt) {
+            function init(elt:Element) {
                 _runtime.initElement(elt);
             }
 
-            function evaluate(str) {
+            function evaluate(str:string) {
                 return _runtime.evaluate(str);
             }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,0 +1,93 @@
+/*********************************
+Interfaces
+
+This file defines all of the interfaces and types used in Hyperscript.  
+No runnable code should go here.
+*/
+
+// Function signatures for the public API
+// TODO: updated "any" references with actual types
+interface Hyperscript {
+	lexer: Lexer
+	parser: Parser
+	runtime: Runtime
+	evaluate: (str:string) => any
+	init: (elt:Element) => void
+	start: (scriptAttrs:any) => boolean
+}
+
+
+// Function signatures for _lexer object.
+// TODO: updated "any" references with actual types
+interface Lexer {
+	tokenize: (string:string) => Tokens
+}
+
+interface Token {
+    line?: number
+    col?: number
+    op?: boolean
+    value?: any
+    type?: any
+    start?: number
+    end?: number
+    column?: number
+}
+
+interface Tokens {
+    matchAnyOpToken: any
+    matchOpToken: any
+    requireOpToken: any
+    matchTokenType: any
+    requireTokenType: any
+    consumeToken: any
+    matchToken: any
+    requireToken: any
+    list: any
+    source: any
+    hasMore: any
+    currentToken: any
+    consumeUntilWhitespace: any
+}
+
+// Function signatures for _parser object.
+// TODO: updated "any" references with actual types
+interface Parser {
+    parseElement: (type:any, tokens?:any, root?:any) => any
+    parseAnyOf: (types:any, tokens:any) => any
+    parseHyperScript: (tokens:any) => any
+    raiseParseError: (tokens:any, message:string) => any
+    addGrammarElement: (name:string, definition:GrammarElement) => any
+    transpile: (node:any, defaultVal?:any) => string
+}
+
+interface GrammarElement {
+    (parser:Parser, tokens:Tokens): (GrammarElementResult | undefined)
+}
+
+// TODO: updated "any" references with actual types
+interface GrammarElementResult {
+	type: string
+	classRef?: any
+	attributeRef?: any
+	on?:any
+    fields?: {name: string, value: any}[]
+    transpile: () => string
+}
+
+// Function signatures for _runtime object.  
+// TODO: updated "any" references with actual types
+interface Runtime {
+		typeCheck: (value:any, typeString:string, nullOk:boolean) => any
+		forEach: (arr:any[], func:any) => void
+		evalTarget: (root:any, path:any) => any
+		triggerEvent: (elt:Element, eventName:string, detail:Object) => boolean
+		matchesSelector: (elt:Element, selector:string) => boolean
+		getScript: (elt:Element) => (string | null)
+		applyEventListeners: (hypeScript, elt:Element) => void
+		setScriptAttrs: (values:string[]) => void
+		initElement: (elt:Element) => any
+		evaluate: (typeOrSrc:any, srcOrCtx?:any, ctxArg?:any) => any
+		getScriptSelector: () => any
+		ajax: (method:string, url:string, callback:any, data:any) => any
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -24,11 +24,11 @@ interface Lexer {
 }
 
 interface Token {
+    type: string
+    value?: string
+    op?: boolean
     line?: number
     col?: number
-    op?: boolean
-    value?: any
-    type?: any
     start?: number
     end?: number
     column?: number
@@ -71,8 +71,14 @@ interface GrammarElementResult {
 	classRef?: any
 	attributeRef?: any
 	on?:any
-    fields?: {name: string, value: any}[]
-    transpile: () => string
+    fields?: GrammarElementField[]
+    transpile: () => (string | number)
+}
+
+
+interface GrammarElementField {
+	name: any
+	value: any
 }
 
 // Function signatures for _runtime object.  

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -56,23 +56,27 @@ interface Parser {
     parseElement: (type:any, tokens?:any, root?:any) => any
     parseAnyOf: (types:any, tokens:any) => any
     parseHyperScript: (tokens:any) => any
-    raiseParseError: (tokens:any, message:string) => any
+    raiseParseError: (tokens:any, message?:string) => any
     addGrammarElement: (name:string, definition:GrammarElement) => any
     transpile: (node:any, defaultVal?:any) => string
 }
 
 interface GrammarElement {
-    (parser:Parser, tokens:Tokens): (GrammarElementResult | undefined)
+    (parser:Parser, tokens:Tokens, root?:any): (GrammarElementResult | undefined)
 }
 
 // TODO: updated "any" references with actual types
 interface GrammarElementResult {
 	type: string
+	target?: any
+	op?: any
+	symbolWrite?: boolean
+	value?: any
 	classRef?: any
 	attributeRef?: any
 	on?:any
     fields?: GrammarElementField[]
-    transpile: () => (string | number)
+    transpile: () => (string | number | undefined)
 }
 
 

--- a/test/index.html
+++ b/test/index.html
@@ -27,7 +27,7 @@
 <script src="../node_modules/chai/chai.js"></script>
 <script src="../node_modules/mocha/mocha.js"></script>
 <script src="../node_modules/sinon/pkg/sinon.js"></script>
-<script src="../src/_hyperscript.js"></script>
+<script src="../dist/_hyperscript.js"></script>
 <script class="mocha-init">
     mocha.setup('bdd');
     mocha.checkLeaks();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"allowJs": false,
+		"checkJs": false,
+		"noImplicitAny": false, // TODO
+		"noImplicitThis": false, // TODO
+		"outFile": "dist/_hyperscript.js",
+		"strict": false, // TODO
+		"strictBindCallApply": false, // TODO
+		"strictFunctionTypes": false, // TODO
+		"strictNullChecks": true,
+		"strictPropertyInitialization": true,
+		"target": "ES6"
+	},
+	"include":[
+		"src/*"
+	],
+	"exclude": [
+		"node_modules"
+	]
+}


### PR DESCRIPTION
This is not the best pull request.  But it's a start.  I've converted the library into Typescript by renaming the file ".ts" and adding a number of type definitions into the code, with only a handful of minimal changes to the code itself (for instance, adding a null check).  

**All automated Mocha tests are passing**, but I have not done any additional testing beyond that.

There is also a new "interfaces.ts" file that does not contain any code but does provide all of the interfaces I could recognize from the original source.  This would be a good place to start to see if I did this correctly.

I'm trying to be VERY conservative by not making assumptions about the data in many kinds of objects, so there are many places still marked as "any" that an experienced developer could fill in with more concrete values.  The goal would be to rachet up the specificity of all of the type definitions over time, and to lock down more of the "strict" checks that Typescript can provide in the source code.

Please let me know if this is a good start, or if you'd like to see this go another way.  I'm happy to take some direction on this if it will be helpful to the Hyperscript/HTMX project.