### PR TITLE
Fix initialization problem

### DIFF
--- a/src/_hyperscript.js
+++ b/src/_hyperscript.js
@@ -1733,7 +1733,7 @@
             //====================================================================
             function ready(fn) {
                 if (document.readyState !== 'loading') {
-                    fn();
+                    setTimeout(fn,0);
                 } else {
                     document.addEventListener('DOMContentLoaded', fn);
                 }


### PR DESCRIPTION
If you include Hyperscript as a `<script>` tag with `defer` attribute, the `ready` implementation immediately runs the init fn, but _hyperscript is not (yet) defined on `window`. Use  `setTimeout` to run the init fn on the next tick, which seems to fix the issue. 

The error that happens is:

```
hyperscript.js:602 Uncaught ReferenceError: _hyperscript is not defined
    at getScriptAttributes (hyperscript.js:602)
    at Object.getScriptSelector (hyperscript.js:626)
    at Object.processNode (hyperscript.js:668)
    at processNode (hyperscript.js:2153)
    at hyperscript.js:2196
    at ready (hyperscript.js:2165)
    at hyperscript.js:2194
    at hyperscript.js:2214
    at hyperscript.js:8
    at hyperscript.js:10
```