### PR TITLE
Embedded JS

### DIFF
--- a/src/_hyperscript.js
+++ b/src/_hyperscript.js
@@ -42,6 +42,11 @@
                 }
             }
 
+            // https://stackoverflow.com/a/8843181
+            function varargConstructor(Cls, args) {
+                return new (Cls.bind.apply(Cls, [Cls].concat(args)));
+            }
+
             function assignToNamespace(nameSpace, name, value) {
                 // we use window instead of globalScope here so that we can
                 // intercept this in workers
@@ -1484,7 +1489,7 @@
 
                 _parser.addGrammarElement("command", function (parser, tokens) {
                     return parser.parseAnyOf(["addCmd", "removeCmd", "toggleCmd", "waitCmd", "returnCmd", "sendCmd", "triggerCmd",
-                        "takeCmd", "logCmd", "callCmd", "putCmd", "setCmd", "ifCmd", "forCmd", "fetchCmd", "throwCmd"], tokens);
+                        "takeCmd", "logCmd", "callCmd", "putCmd", "setCmd", "ifCmd", "forCmd", "fetchCmd", "throwCmd", "jsCmd"], tokens);
                 })
 
                 _parser.addGrammarElement("commandList", function (parser, tokens) {
@@ -1871,20 +1876,6 @@
                 _parser.addGrammarElement("jsFeature", function(parser, tokens) {
                     if (tokens.matchToken('js')) {
 
-                        // // Parse inputs
-                        // var inputs = [];
-                        // if (tokens.matchOpToken("(")) {
-                        //     if (tokens.matchOpToken(")")) {
-                        //         // empty input list
-                        //     } else {
-                        //         do {
-                        //             var inp = tokens.requireTokenType('IDENTIFIER');
-                        //             inputs.push(inp);
-                        //         } while (tokens.matchOpToken(","));
-                        //         tokens.requireOpToken(')');
-                        //     }
-                        // }
-
                         // eat tokens until `end`
 
                         var jsSourceStart = tokens.currentToken().start;
@@ -1912,6 +1903,68 @@
                                 mergeObjects(globalScope, func())
                             }
                         }
+                    }
+                })
+
+                _parser.addGrammarElement("jsCmd", function (parser, tokens) {
+                    if (tokens.matchToken('js')) {
+
+                        // Parse inputs
+                        var inputs = [];
+                        if (tokens.matchOpToken("(")) {
+                            if (tokens.matchOpToken(")")) {
+                                // empty input list
+                            } else {
+                                do {
+                                    var inp = tokens.requireTokenType('IDENTIFIER');
+                                    inputs.push(inp.value);
+                                } while (tokens.matchOpToken(","));
+                                tokens.requireOpToken(')');
+                            }
+                        }
+
+                        // eat tokens until `end`
+
+                        var jsSourceStart = tokens.currentToken().start;
+                        var jsLastToken = null;
+
+                        while (tokens.hasMore()) {
+                            jsLastToken = tokens.consumeToken()
+                            if (jsLastToken.type === "IDENTIFIER"
+                                && jsLastToken.value === "end") {
+                                break;
+                            }
+                        }
+
+                        var jsSourceEnd = jsLastToken.start;
+
+                        var jsSource = tokens.source.substring(jsSourceStart, jsSourceEnd);
+
+                        var func = varargConstructor(Function, inputs.concat([jsSource]));
+
+                        var callCmd;
+                        return callCmd = {
+                            type: "jsCmd",
+                            jsSource: "jsSource",
+                            function: func,
+                            inputs: inputs,
+                            execute: function(ctx) {
+                                var args = [];
+                                inputs.forEach(function (input) {
+                                    args.push(_runtime.resolveSymbol(input, ctx))
+                                });
+                                var result = func.apply(globalScope, args)
+                                if (result && typeof result.then === 'function') {
+                                    result.then(function(actualResult) {
+                                        ctx.it = actualResult
+                                        _runtime.next(this, ctx)
+                                    })
+                                } else {
+                                    ctx.it = result
+                                    _runtime.next(this, ctx)
+                                }
+                            }
+                        };
                     }
                 })
 

--- a/src/_hyperscript.js
+++ b/src/_hyperscript.js
@@ -136,6 +136,10 @@
                     return (c === "_" || c === "$");
                 }
 
+                function isReservedChar(c) {
+                    return (c === "`" || c === "^");
+                }
+
 
                 function makeTokensObject(tokens, consumed, source) {
 
@@ -273,6 +277,8 @@
                                 tokens.push(consumeString());
                             } else if (OP_TABLE[currentChar()]) {
                                 tokens.push(consumeOp());
+                            } else if (isReservedChar(currentChar())) {
+                                tokens.push(makeToken('RESERVED', currentChar))
                             } else {
                                 if (position < source.length) {
                                     throw Error("Unknown token: " + currentChar() + " ");

--- a/src/_hyperscript.js
+++ b/src/_hyperscript.js
@@ -1938,6 +1938,9 @@
                             jsLastToken = tokens.consumeToken()
                             if (jsLastToken.type === "IDENTIFIER"
                                 && jsLastToken.value === "end") {
+                                // we wrongly eat the end token, we deal with this
+                                // in the "hyperscript" production
+                                // TODO: fix, needs lookahead?
                                 break;
                             }
                         }

--- a/test/commands/js.js
+++ b/test/commands/js.js
@@ -33,7 +33,7 @@ describe('The (inline) js command', function () {
 
     it('can return values to _hyperscript', function () {
     	var div = make("<div _=\"on click js return 'test success' end " +
-    				   "        then put it in my.innerHTML\"></div>");
+    				   "        then put it into my.innerHTML\"></div>");
     	div.click();
     	div.innerHTML.should.equal('test success');
     })

--- a/test/commands/js.js
+++ b/test/commands/js.js
@@ -1,0 +1,40 @@
+describe('The (inline) js command', function () {
+	beforeEach(function () {
+        clearWorkArea();
+    });
+    afterEach(function () {
+        clearWorkArea();
+    });
+
+    it('can run js', function () {
+    	window.testSuccess = false
+    	var div = make('<div _="on click js window.testSuccess = true end"></div>');
+    	div.click();
+    	assert.equal(window.testSuccess, true);
+    	delete window.testSuccess;
+    })
+
+    it('can deal with empty input list', function () {
+    	window.testSuccess = false
+    	var div = make('<div _="on click js() window.testSuccess = true end"></div>');
+    	div.click();
+    	assert.equal(window.testSuccess, true);
+    	delete window.testSuccess;
+    })
+
+    it('can access values from _hyperscript', function () {
+    	window.testSuccess = false
+    	var div = make("<div _='on click set t to true " + 
+    					"       then js(t) window.testSuccess = t end'></div>");
+    	div.click();
+    	assert.equal(window.testSuccess, true);
+    	delete window.testSuccess;
+    })
+
+    it('can return values to _hyperscript', function () {
+    	var div = make("<div _=\"on click js return 'test success' end " +
+    				   "        then put it in my.innerHTML\"></div>");
+    	div.click();
+    	div.innerHTML.should.equal('test success');
+    })
+})

--- a/test/commands/js.js
+++ b/test/commands/js.js
@@ -37,4 +37,12 @@ describe('The (inline) js command', function () {
     	div.click();
     	div.innerHTML.should.equal('test success');
     })
+
+    it('can do both of the above', function () {
+    	var div = make("<div _=\"on click set a to 1 " +
+    				   "         then js(a) return a + 1 end " +
+    				   "         then put it into my.innerHTML\"></div>");
+    	div.click();
+    	div.innerHTML.should.equal('2');
+    })
 })

--- a/test/features/js.js
+++ b/test/features/js.js
@@ -1,0 +1,31 @@
+describe('The (top-level) js feature', function () {
+	beforeEach(function () {
+        clearWorkArea();
+    });
+    afterEach(function () {
+        clearWorkArea();
+    });
+
+    it('can run js at the top level', function() {
+    	window.testSuccess = false
+    	var script = make("<script type=text/hyperscript>" +
+    					  "  js " +
+    					  "    window.testSuccess = true " +
+    					  "  end ");
+    	assert.equals(window.testSuccess, true);
+    	delete window.testSuccess;
+    })
+
+    it('can declare functions, which are then accessible from hyperscript', function() {
+    	window.testSuccess = false
+    	var script = make("<script type=text/hyperscript>" +
+    					  "  js " +
+    					  "    function foo() { " +
+    					  "      return 'test succeeded'; " +
+    					  "    } " +
+    					  "  end ");
+    	var div = make("<div _='on click put foo() into my.innerHTML'>test failed</div>")
+    	div.click()
+    	div.innerHTML.should.equal('test succeeded');
+    })
+})

--- a/test/features/js.js
+++ b/test/features/js.js
@@ -12,30 +12,28 @@ describe('The (top-level) js feature', function () {
     					  "  js " +
     					  "    window.testSuccess = true " +
     					  "  end ");
-    	assert.equals(window.testSuccess, true);
+    	assert.equal(window.testSuccess, true);
     	delete window.testSuccess;
     })
 
     it('can expose globals', function() {
-    	window.testSuccess = false
     	var script = make("<script type=text/hyperscript>" +
     					  "  js " +
-    					  "    return { foo: 'test succeeded' }; "
+    					  "    return { foo: 'test succeeded' }; " +
     					  "  end ");
-    	assertEquals(window.foo, 'test succeeded')
+    	assert.equal(window.foo, 'test succeeded')
     	delete window.foo
     })
 
     it('can expose functions', function() {
-    	window.testSuccess = false
     	var script = make("<script type=text/hyperscript>" +
     					  "  js " +
     					  "    function foo() { " +
     					  "      return 'test succeeded'; " +
     					  "    } " +
-    					  "    return { foo: foo }; "
+    					  "    return { foo: foo }; " +
     					  "  end ");
-    	assertEquals(window.foo(), 'test succeeded')
+    	assert.equal(window.foo(), 'test succeeded')
     	delete window.foo
     })
 })

--- a/test/features/js.js
+++ b/test/features/js.js
@@ -16,16 +16,26 @@ describe('The (top-level) js feature', function () {
     	delete window.testSuccess;
     })
 
-    it('can declare functions, which are then accessible from hyperscript', function() {
+    it('can expose globals', function() {
+    	window.testSuccess = false
+    	var script = make("<script type=text/hyperscript>" +
+    					  "  js " +
+    					  "    return { foo: 'test succeeded' }; "
+    					  "  end ");
+    	assertEquals(window.foo, 'test succeeded')
+    	delete window.foo
+    })
+
+    it('can expose functions', function() {
     	window.testSuccess = false
     	var script = make("<script type=text/hyperscript>" +
     					  "  js " +
     					  "    function foo() { " +
     					  "      return 'test succeeded'; " +
     					  "    } " +
+    					  "    return { foo: foo }; "
     					  "  end ");
-    	var div = make("<div _='on click put foo() into my.innerHTML'>test failed</div>")
-    	div.click()
-    	div.innerHTML.should.equal('test succeeded');
+    	assertEquals(window.foo(), 'test succeeded')
+    	delete window.foo
     })
 })

--- a/test/index.html
+++ b/test/index.html
@@ -48,6 +48,7 @@
 <script src="features/on.js"></script>
 <script src="features/def.js"></script>
 <script src="features/worker.js"></script>
+<script src="features/js.js"></script>
 
 <!-- commands -->
 <script src="commands/add.js"></script>
@@ -65,6 +66,7 @@
 <script src="commands/for.js"></script>
 <script src="commands/fetch.js"></script>
 <script src="commands/throw.js"></script>
+<script src="commands/js.js"></script>
 
 <!-- expressions -->
 <script src="expressions/strings.js"></script>


### PR DESCRIPTION
This PR contains functionality to embed JS into \_hyperscript in two ways:

- At the top level, among defs and workers
- Inline, among commands

## Samples

```hyperscript
js
	function foo() {
    	// some garbage js
	}

	// functions are private by default and can be exposed to
	// the global scope by returning them in an object:
	return { foo }
end

def foo()
  set x to 10
  js(x)
    // IIFE
    return x + someJavscriptFunction()
  end
  log it
end
```

## Reserved tokens

As part of this, the lexer generates `"RESERVED"` tokens for the characters `` ` ^ ``, since these can occur in JavaScript. These tokens won't be recognized by the parser outside of JS blocks.