### PR TITLE
Typo: hanlder -> handler

### DIFF
--- a/www/features/on.md
+++ b/www/features/on.md
@@ -3,7 +3,7 @@ layout: layout.njk
 title: ///_hyperscript
 ---
 
-## The `event hanlder` Feature
+## The `event handler` Feature
 
 ### Syntax
 


### PR DESCRIPTION
Just a tiny typo I spotted while reading the docs