### PR TITLE
Toggle between <x> and <y> syntax

### DIFF
--- a/test/commands/toggle.js
+++ b/test/commands/toggle.js
@@ -33,7 +33,6 @@ describe("the toggle command", function() {
         var div = make("<div _='on click toggle [foo=\"bar\"]'></div>");
         div.hasAttribute("foo").should.equal(false);
         div.click();
-        console.log(div, div.getAttribute)
         div.getAttribute("foo").should.equal("bar");
         div.click();
         div.hasAttribute("foo").should.equal(false);

--- a/test/commands/toggle.js
+++ b/test/commands/toggle.js
@@ -33,6 +33,7 @@ describe("the toggle command", function() {
         var div = make("<div _='on click toggle [foo=\"bar\"]'></div>");
         div.hasAttribute("foo").should.equal(false);
         div.click();
+        console.log(div, div.getAttribute)
         div.getAttribute("foo").should.equal("bar");
         div.click();
         div.hasAttribute("foo").should.equal(false);
@@ -62,6 +63,72 @@ describe("the toggle command", function() {
         }, 1);
     })
 
+    // TOGGLE BETWEEN...
+
+    it("can toggle between two classes", function(done) {
+        var div = make(`<div _="on click toggle between .foo and .bar"></div>`);
+        div.classList.contains("foo").should.equal(false)
+        div.classList.contains("bar").should.equal(false)
+        div.click()
+        div.classList.contains("foo").should.equal(true)
+        div.classList.contains("bar").should.equal(false)
+        div.click()
+        div.classList.contains("foo").should.equal(false)
+        div.classList.contains("bar").should.equal(true)
+        div.click()
+        div.classList.contains("foo").should.equal(true)
+        div.classList.contains("bar").should.equal(false)
+        done()
+    })
+
+    it("can toggle between two attribute settings", function(done) {
+        var div = make(`<div _="on click toggle between [foo='bar'] and [bar='baz']"></div>`);
+
+        div.hasAttribute("foo").should.equal(false);
+        div.hasAttribute("bar").should.equal(false);
+        div.click();
+        div.getAttribute("foo").should.equal("bar");
+        div.hasAttribute("bar").should.equal(false);
+        div.click();
+        div.hasAttribute("foo").should.equal(false);
+        div.getAttribute("bar").should.equal("baz");
+        div.click();
+        div.getAttribute("foo").should.equal("bar");
+        div.hasAttribute("bar").should.equal(false);
+        done()
+    })
+
+
+    it("can toggle between two classes for a fixed amount of time", function (done) {
+        var div = make("<div class='foo' _='on click toggle between .foo and .bar for 10ms'></div>");
+        div.classList.contains("foo").should.equal(true);
+        div.classList.contains("bar").should.equal(false);
+        div.click();
+        div.classList.contains("foo").should.equal(false);
+        div.classList.contains("bar").should.equal(true);
+
+        setTimeout(function () {
+            div.classList.contains("foo").should.equal(true);
+            div.classList.contains("bar").should.equal(false);
+            done();
+        }, 20);
+    })
+
+    it("can toggle between two classes until an event on another element", function (done) {
+        var d1 = make("<div id='d1'></div>");
+        var div = make("<div class='bar' _='on click toggle between .foo and .bar until foo from #d1'></div>");
+        div.classList.contains("foo").should.equal(false);
+        div.classList.contains("bar").should.equal(true);
+        div.click();
+        div.classList.contains("foo").should.equal(true);
+        div.classList.contains("bar").should.equal(false);
+        d1.dispatchEvent(new CustomEvent("foo"));
+        setTimeout(function () {
+            div.classList.contains("foo").should.equal(false);
+            div.classList.contains("bar").should.equal(true);
+            done();
+        }, 1);
+    })
 
 });
 


### PR DESCRIPTION
This PR addresses issue #55.  It adds "between ... and ..." as a new potential grammar, and will then switch between the two options for every toggle.  It works seamlessly with classes and attributes, along with other toggle options such as `for` and `until`.

I've added unit tests to demonstrate this.  Will update documentation when this PR is approved by the boss.