### PR TITLE
Object literal improvements

### DIFF
--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -1447,7 +1447,8 @@
                 			evaluate: function() { return this.key }
                 		};
                 	} else if (tokens.matchOpToken("[")) {
-                		var expr = parser.parseElement("expression");
+                		var expr = parser.parseElement("expression", tokens);
+                		tokens.requireOpToken("]");
                 		return {
                 			type: "objectKey",
                 			expr: expr,
@@ -1460,9 +1461,11 @@
                 	} else {
                 		var key = "";
                 		do {
-                			token = tokens.matchTokenType("IDENTIFIER", "MINUS");
+                			token = tokens.matchTokenType("IDENTIFIER") || tokens.matchOpToken("-");
+                			if (token) console.debug("tok: ", token);
 							if (token) key += token.value;
                 		} while (token)
+                		console.debug("key: ", key)
                 		return {
 	               			type: "objectKey",
 	               			key: key,

--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -1438,29 +1438,60 @@
                     }
                 })
 
+                _parser.addGrammarElement("objectKey", function(parser, runtime, tokens) {
+                	var token;
+                	if (token = tokens.matchTokenType("STRING")) {
+                		return {
+                			type: "objectKey",
+                			key: token.value,
+                			evaluate: function() { return this.key }
+                		};
+                	} else if (tokens.matchOpToken("[")) {
+                		var expr = parser.parseElement("expression");
+                		return {
+                			type: "objectKey",
+                			expr: expr,
+                			args: [expr],
+                			op: function (ctx, expr) { return expr },
+                			evaluate: function (context) {
+                                return runtime.unifiedEval(this, context);
+                            }
+                		}
+                	} else {
+                		var key = "";
+                		do {
+                			token = tokens.matchTokenType("IDENTIFIER", "MINUS");
+							if (token) key += token.value;
+                		} while (token)
+                		return {
+	               			type: "objectKey",
+	               			key: key,
+	               			evaluate: function() { return this.key }
+	               		};
+                	}
+                })
+
                 _parser.addLeafExpression("objectLiteral", function(parser, runtime, tokens) {
                     if (tokens.matchOpToken("{")) {
-                        var fields = []
+                        var keyExpressions = []
                         var valueExpressions = []
                         if (!tokens.matchOpToken("}")) {
                             do {
-                                var name = tokens.requireTokenType("IDENTIFIER", "STRING");
+                                var name = parser.requireElement("objectKey", tokens);
                                 tokens.requireOpToken(":");
                                 var value = parser.requireElement("expression", tokens);
                                 valueExpressions.push(value);
-                                fields.push({name: name, value: value});
+                                keyExpressions.push(name);
                             } while (tokens.matchOpToken(","))
                             tokens.requireOpToken("}");
                         }
                         return {
                             type: "objectLiteral",
-                            fields: fields,
-                            args: [valueExpressions],
-                            op:function(context, values){
+                            args: [keyExpressions, valueExpressions],
+                            op:function(context, keys, values){
                                 var returnVal = {};
-                                for (var i = 0; i < values.length; i++) {
-                                    var field = fields[i];
-                                    returnVal[field.name.value] = values[i];
+                                for (var i = 0; i < keys.length; i++) {
+                                    returnVal[keys[i]] = values[i];
                                 }
                                 return returnVal;
                             },

--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -1462,10 +1462,8 @@
                 		var key = "";
                 		do {
                 			token = tokens.matchTokenType("IDENTIFIER") || tokens.matchOpToken("-");
-                			if (token) console.debug("tok: ", token);
 							if (token) key += token.value;
                 		} while (token)
-                		console.debug("key: ", key)
                 		return {
 	               			type: "objectKey",
 	               			key: key,

--- a/test/expressions/objectLiteral.js
+++ b/test/expressions/objectLiteral.js
@@ -20,4 +20,18 @@ describe("the objectLiteral expression", function () {
         result.should.deep.equal({foo:true, bar:false});
     });
 
+    it("hyphens work in object literal field names", function () {
+        var result = evalHyperScript("{-foo:true, bar-baz:false}")
+        result.should.deep.equal({"-foo":true, "bar-baz":false});
+    });
+
+    it("expressions work in object literal field names", function () {
+    	window.foo = "bar";
+    	window.bar = function () { return "foo" };
+        var result = evalHyperScript("{[foo]:true, [bar()]:false}");
+        result.should.deep.equal({bar:true, foo:false});
+        delete window.foo;
+        delete window.bar;
+    });
+
 });


### PR DESCRIPTION
The following now work as expected: 
- `{foo-bar: "baz"}`
- `{[foo.bar()]: "baz"}`