### PR TITLE
`set` cmd: Set many properties at once using an object literal

### DIFF
--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -2987,6 +2987,21 @@
 
                 _parser.addCommand("set", function(parser, runtime, tokens) {
                     if (tokens.matchToken('set')) {
+						if (tokens.currentToken().type === "L_BRACE") {
+							var obj = parser.requireElement("objectLiteral", tokens);
+							tokens.requireToken("on");
+							var target = parser.requireElement("expression", tokens);
+
+							return {
+								objectLiteral: obj,
+								target: target,
+								args: [obj, target],
+								op: function (ctx, obj, target) {
+									mergeObjects(target, obj);
+								}
+							}
+						}
+
                         var target = parser.requireElement("target", tokens);
 
                         tokens.requireToken("to");

--- a/test/commands/set.js
+++ b/test/commands/set.js
@@ -95,5 +95,12 @@ describe("the set command", function() {
         }
     })
 
+	it("can set many properties at once with object literal", function() {
+		window.obj = {foo: 1};
+		make("<div _='on click set {bar: 2, baz: 3} on obj'></div>").click();
+		obj.should.deep.equal({foo: 1, bar: 2, baz: 3});
+		delete window.obj;
+	})
+
 });
 


### PR DESCRIPTION
The following now works: 

```hyperscript
set obj to { foo: 1 }
set { bar: 2, baz: 3 } on obj
```