### PR TITLE
add cmd: Add css properties with object literal

### DIFF
--- a/test/commands/add.js
+++ b/test/commands/add.js
@@ -43,5 +43,14 @@ describe("the add command", function() {
         div.getAttribute("foo").should.equal("bar");
     })
 
+    it("can add css properties", function(){
+        var div = make("<div style='color: blue' " +
+                       "    _='on click add {color: \"red\", \"font-family\": \"monospace\"}'></div>");
+        div.style.color.should.equal("blue");
+        div.click();
+        div.style.color.should.equal("red");
+        div.style.fontFamily.should.equal("monospace");
+    })
+
 });
 


### PR DESCRIPTION
The following now works:

```hyperscript
add { color: 'red', 'font-size': calcFontSize() } to #elt
```

(the quotes around `'font-size'` will be unnecessary with #61)