### PR TITLE
Fix `take` command

### DIFF
--- a/src/lib/web.js
+++ b/src/lib/web.js
@@ -442,7 +442,7 @@
 
     _hyperscript.addCommand("take", function(parser, runtime, tokens) {
         if (tokens.matchToken('take')) {
-            var classRef = tokens.requireTokenType(tokens, "CLASS_REF");
+            var classRef = parser.parseElement("classRef", tokens);
 
             if (tokens.matchToken("from")) {
                 var from = parser.requireElement("targetExpression", tokens);
@@ -462,7 +462,7 @@
                 forElt: forElt,
                 args: [from, forElt],
                 op: function (context, from, forElt) {
-                    var clazz = this.classRef.value.substr(1)
+                    var clazz = this.classRef.css.substr(1)
                     runtime.forEach(from, function (target) {
                         target.classList.remove(clazz);
                     })


### PR DESCRIPTION
I probably should've opened an issue for this first, but the `take` command was failing for me with the error `e.classList is undefined` when I used it without a target. This PR fixes that.

The code that was breaking: 

```hyperscript
on click
  with closest <li/> to target
    take .active -- this was breaking
    ...
  end
```