### PR TITLE
Updates to `as Values`

### DIFF
--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -3784,9 +3784,6 @@
                     addIndirectExpression: function (keyword, definition) {
                         _parser.addIndirectExpression(definition);
                     },
-                    forEach: function(value, func) {
-                        _runtime.forEach(value, func);
-                    },
                     evaluate: function (str, ctx) { //OK
                         return _runtime.evaluate(str, ctx); //OK
                     },

--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -893,11 +893,16 @@
                     }
                     parser.raiseParseError(tokens, "Unexpected value: " + tokens.currentToken().value);
                 });
+
                 /* ============================================================================================ */
                 /* END Core hyperscript Grammar Elements                                                        */
                 /* ============================================================================================ */
 
-
+                /**
+                 * 
+                 * @param {TokensObject} tokens 
+                 * @returns string
+                 */
                 function createParserContext(tokens) {
                     var currentToken = tokens.currentToken();
                     var source = tokens.source;
@@ -1110,16 +1115,25 @@
                 }
 
                 /**
+                 * isArrayLike returns `true` if the provided value is an array or
+                 * a NodeList (which is close enough to being an array for our purposes).
+                 * 
                  * @param {any} value 
-                 * @returns boolean
+                 * @returns {value is Array | NodeList}
                  */
                 function isArrayLike(value) {
                     return Array.isArray(value) || value instanceof NodeList;
                 }
 
                 /**
-                 * @param {any} value 
-                 * @param {function} func 
+                 * forEach executes the provided `func` on every item in the `value` array.
+                 * if `value` is a single item (and not an array) then `func` is simply called
+                 * once.  If `value` is null, then no further actions are taken.
+                 * 
+                 * @function
+                 * @template T
+                 * @param {T | T[]} value 
+                 * @param {(item:T) => void} func 
                  */
                 function forEach(value, func) {
                     if (value == null) {
@@ -3759,16 +3773,19 @@
                         runtime: _runtime,
                     },
                     addFeature: function (keyword, definition) {
-                        _parser.addFeature(keyword, definition)
+                        _parser.addFeature(keyword, definition);
                     },
                     addCommand: function (keyword, definition) {
-                        _parser.addCommand(keyword, definition)
+                        _parser.addCommand(keyword, definition);
                     },
                     addLeafExpression: function (name, definition) {
-                        _parser.addLeafExpression(name, definition)
+                        _parser.addLeafExpression(name, definition);
                     },
                     addIndirectExpression: function (keyword, definition) {
-                        _parser.addIndirectExpression(definition)
+                        _parser.addIndirectExpression(definition);
+                    },
+                    forEach: function(value, func) {
+                        _runtime.forEach(value, func);
                     },
                     evaluate: function (str, ctx) { //OK
                         return _runtime.evaluate(str, ctx); //OK

--- a/src/lib/web.js
+++ b/src/lib/web.js
@@ -685,7 +685,9 @@
         /** @type Object<string,string | string[]> */
         var result = {};
 
-        _hyperscript.forEach(node, function(/** @type HTMLInputElement */ node) {
+        var forEach = _hyperscript.internals.runtime.forEach;
+
+        forEach(node, function(/** @type HTMLInputElement */ node) {
 
             // Try to get a value directly from this node
             var input = getInputInfo(node);
@@ -698,7 +700,7 @@
             // Otherwise, try to query all child elements of this node that *should* contain values.
             if (node.querySelectorAll != undefined) {
                 var children = node.querySelectorAll("input,select,textarea");
-                _hyperscript.forEach(children, appendValue);
+                forEach(children, appendValue);
             }
         })
 

--- a/src/lib/web.js
+++ b/src/lib/web.js
@@ -680,39 +680,36 @@
         }
     });
 
-    _hyperscript.config.conversions["Values"] = function(node) {
+    _hyperscript.config.conversions["Values"] = function(/** @type {Node | NodeList} */ node) {
 
-        // Try to get a value directly from this node
-        var input = getInputInfo(node);
+        console.log(node)
 
-        if (input !== undefined) {
-            return input.value;
-        }
+        /** @type Object<string,string | string[]> */
+        var result = {};
 
-        // Otherwise, try to query all child elements of this node that *should* contain values.
-        if (node.querySelectorAll != undefined) {
+        _hyperscript.forEach(node, function(/** @type HTMLInputElement */ node) {
 
-            /** @type Object<string,string> */
-            var result = {};
+            // Try to get a value directly from this node
+            var input = getInputInfo(node);
 
-            var children = node.querySelectorAll("input,select,textarea");
-
-            for (var i = 0; i < children.length; i++) {
-                var child = children[i];
-                appendValue(result, child);
+            if (input !== undefined) {
+                result[input.name] = input.value;
+                return;
             }
 
-            return result;
-        }
+            // Otherwise, try to query all child elements of this node that *should* contain values.
+            if (node.querySelectorAll != undefined) {
+                var children = node.querySelectorAll("input,select,textarea");
+                _hyperscript.forEach(children, appendValue);
+            }
+        })
 
-        // Otherwise, there is no value to return.
-        return null;
+        return result;
 
         /**
-         * @param {Object<string,(string|string[])>} result
          * @param {HTMLInputElement} node 
          */
-        function appendValue(result, node) {
+        function appendValue(node) {
 
             var info = getInputInfo(node);
 

--- a/src/lib/web.js
+++ b/src/lib/web.js
@@ -682,8 +682,6 @@
 
     _hyperscript.config.conversions["Values"] = function(/** @type {Node | NodeList} */ node) {
 
-        console.log(node)
-
         /** @type Object<string,string | string[]> */
         var result = {};
 

--- a/test/expressions/asExpression.js
+++ b/test/expressions/asExpression.js
@@ -56,16 +56,16 @@ describe("as operator", function() {
         result["foo"].should.equal('bar');
     })
 
-    it("converts an input element into a Value", function() {
+    it("converts an input element into Values", function() {
         var node = document.createElement("input")
         node.name = "test-name"
         node.value = "test-value"
 
         var result = evalHyperScript("x as Values", {x:node})
-        result.should.equal("test-value")
+        result['test-name'].should.equal("test-value")
     })
 
-    it("converts a form element into a Value", function() {
+    it("converts a form element into Values", function() {
         var node = document.createElement("form");
         node.innerHTML = `
             <input name="firstName" value="John"><br>
@@ -80,6 +80,24 @@ describe("as operator", function() {
         result.lastName.should.equal("Connor");
         result.areaCode.should.equal("213");
         result.phone.should.equal("555-1212");
+    });
+
+    it("converts a query selector into Values", function() {
+        var d1 = make(`<div _="on click put <input.include/> as Values into my.customData"></div>`)
+
+        d1.innerHTML = `
+            <input class="include" name="firstName" value="John"><br>
+            <input class="include" name="lastName" value="Connor"><br>
+            <input class="include" name="areaCode" value="213">
+            <input class="dont-include" name="phone" value="555-1212">
+        `;
+
+        d1.click();
+
+        d1.customData.firstName.should.equal("John");
+        d1.customData.lastName.should.equal("Connor");
+        d1.customData.areaCode.should.equal("213");
+        should.not.exist(d1.customData.phone);
     });
 
     it("converts radio buttons into a Value correctly", function() {


### PR DESCRIPTION
I've updated this so that it will work with a NodeList (and not just a single DOM Node).  This makes `as Values` work with query selectors like this:

```html
<div _="on click put <input.include/> as Values into my.customData">
            <input class="include" name="firstName" value="John"><br>
            <input class="include" name="lastName" value="Connor"><br>
            <input class="include" name="areaCode" value="213">
            <input class="dont-include" name="phone" value="555-1212">
</div>
```

In the case above, only the inputs marked "include" will show up in the customData struct.  The "dont-include" element is ignored.

One notable side-effect of this PR is that `forEach` has been included in hyperscript's public API.