### PR TITLE
Fix "column" typo?

### DIFF
--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -935,7 +935,7 @@
                     var lines = source.split("\n");
                     var line = currentToken ? currentToken.line - 1 : lines.length - 1;
                     var contextLine = lines[line];
-                    var offset = currentToken ? currentToken.column : contextLine.length - 1;
+                    var offset = currentToken ? currentToken.col : contextLine.length - 1;
                     return contextLine + "\n" + " ".repeat(offset) + "^^\n\n";
                 }
 

--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -935,7 +935,7 @@
                     var lines = source.split("\n");
                     var line = currentToken ? currentToken.line - 1 : lines.length - 1;
                     var contextLine = lines[line];
-                    var offset = currentToken ? currentToken.col : contextLine.length - 1;
+                    var offset = currentToken ? currentToken.column : contextLine.length - 1;
                     return contextLine + "\n" + " ".repeat(offset) + "^^\n\n";
                 }
 

--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -146,7 +146,7 @@
                  * @returns string
                  */
                 function positionString(token) {
-                    return "[Line: " + token.line + ", Column: " + token.col + "]"
+                    return "[Line: " + token.line + ", Column: " + token.column + "]"
                 }
 
                 /**

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -68,7 +68,7 @@
  * @property {boolean} [op] // `true` if this token represents an operator
  * @property {number} [start]
  * @property {number} [end]
- * @property {number} [col]
+ * @property {number} [column]
  * @property {number} [line]
  * 
  * 


### PR DESCRIPTION
It appears that tokens have a "col" property, but not a "column" property.  Is this a typo?  If so, then +1 for static analysis!