### PR TITLE
FEATURE "as HTML"

### DIFF
--- a/src/lib/web.js
+++ b/src/lib/web.js
@@ -864,13 +864,12 @@
         }
     }
 
-	_hyperscript.config.conversions["HTML"] = function(/** @type {any} */ value) {
+	_hyperscript.config.conversions["HTML"] = function(value) {
 
-		var toHTML = function(value) {
+		var toHTML = /** @returns {string}*/ function(/** @type any*/ value) {
 
 			if (value instanceof Array) {
-				value = value.map((item) => toHTML(item))
-				return value.join("")
+				return value.map((item) => toHTML(item)).join("")
 			}
 
 			if (value instanceof HTMLElement) {
@@ -892,8 +891,8 @@
 			}
 	
 			return ""
-			}
+		};
 
-		return toHTML(value)
+		return toHTML(value);
 	}
 })()

--- a/src/lib/web.js
+++ b/src/lib/web.js
@@ -864,4 +864,36 @@
         }
     }
 
+	_hyperscript.config.conversions["HTML"] = function(/** @type {any} */ value) {
+
+		var toHTML = function(value) {
+
+			if (value instanceof Array) {
+				value = value.map((item) => toHTML(item))
+				return value.join("")
+			}
+
+			if (value instanceof HTMLElement) {
+				return value.outerHTML
+			}
+
+			if (value instanceof NodeList) {
+				var result = ""
+				for (var node of value) {
+					if (node instanceof HTMLElement) {
+						result += node.outerHTML;
+					}
+				}
+				return result
+			}
+
+			if (value.toString) {
+				return value.toString()
+			}
+	
+			return ""
+			}
+
+		return toHTML(value)
+	}
 })()

--- a/test/expressions/asExpression.js
+++ b/test/expressions/asExpression.js
@@ -196,6 +196,55 @@ describe("as operator", function() {
         result.gender[2].should.equal("Other");
     });
 
+    it("converts an element into HTML", function () {
+        var d1 = document.createElement("div");
+        d1.id = "myDiv";
+        d1.innerText = "With Text";
+
+        var result = evalHyperScript("d as HTML", {d: d1});
+        result.should.equal(`<div id="myDiv">With Text</div>`);
+    })
+
+    it("converts a NodeList into HTML", function () {
+        var fragment = document.createDocumentFragment()
+
+        {
+            var d = document.createElement("div");
+            d.id = "first";
+            d.innerText = "With Text";
+            fragment.appendChild(d)
+        }
+
+        {
+            var d = document.createElement("span");
+            d.id = "second";
+            fragment.appendChild(d)
+        }
+
+        {
+            var d = document.createElement("i");
+            d.id = "third";
+            fragment.appendChild(d)
+        }
+
+        var result = evalHyperScript("nodeList as HTML", {nodeList: fragment.childNodes});
+        result.should.equal(`<div id="first">With Text</div><span id="second"></span><i id="third"></i>`);
+    })
+
+    it("converts an array into HTML", function () {
+        var d1 = ["this-", "is-", "html"]
+
+        var result = evalHyperScript("d as HTML", {d: d1});
+        result.should.equal(`this-is-html`);
+    })
+
+    it("converts numbers things 'HTML'", function () {
+        var value = 123
+
+        var result = evalHyperScript("value as HTML", {value: value});
+        result.should.equal("123");
+    })
+
     it("can accept custom comversions", function () {
         _hyperscript.config.conversions["Foo"] = function(val){
             return "foo" + val;

--- a/www/expressions/as.md
+++ b/www/expressions/as.md
@@ -26,6 +26,7 @@ By default, hyperscript provides the following conversions:
 * `JSON` - convert to a JSON String
 * `Object` - convert from a JSON String
 * `Values` - convert a DOM element to its input values
+* `HTML` - converts NodeLists and arrays to an HTML string
 
 You can add new conversions by adding them to the `_hyperscript.config.conversions` object:
 


### PR DESCRIPTION
This PR adds an "as HTML" converter to the web.js library.  "As HTML" converts different objects as follows: 

* HTML Elements => the element's `outerHTML`
* NodeLists => a concatenated string of each element's `.outerHTML`
* Other Arrays => a concatenated string of each element (with no comma delimiters)
* Anything else => `.toString()` representation

Includes tests and documentation