### PR TITLE
FEATURE: Array Range Notation

### DIFF
--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -620,7 +620,7 @@
                         while (isNumeric(currentChar())) {
                             value += consumeChar();
                         }
-                        if (currentChar() === ".") {
+                        if ((currentChar() === ".") && isNumeric(nextChar())) {
                             value += consumeChar();
                         }
                         while (isNumeric(currentChar())) {
@@ -2453,7 +2453,7 @@
                             if (tokens.matchOpToken("..")) {
                                 andAfter = true
                                 var current = tokens.currentToken()
-                                if ((current.op != true) || (current.value != "]")) {
+                                if (current.type !== "R_BRACKET") {
                                     secondIndex = parser.parseElement("expression", tokens)
                                 }
                             }

--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -2452,7 +2452,10 @@
 
                             if (tokens.matchOpToken("..")) {
                                 andAfter = true
-                                secondIndex = parser.parseElement("expression", tokens)
+                                var current = tokens.currentToken()
+                                if ((current.op != true) || (current.value != "]")) {
+                                    secondIndex = parser.parseElement("expression", tokens)
+                                }
                             }
                         }
                         tokens.requireOpToken("]")
@@ -2464,9 +2467,6 @@
                             secondIndex: secondIndex,
                             args: [root, firstIndex, secondIndex],
                             op: function(_ctx, root, firstIndex, secondIndex) {
-
-                                console.log(firstIndex, secondIndex, andBefore, andAfter)
-
                                 if (andBefore) {
                                     return root.slice(0, firstIndex + 1) // returns all items from beginning to firstIndex (inclusive)
                                 } else if (andAfter) {

--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -85,7 +85,7 @@
                     '*': 'MULTIPLY',
                     '/': 'DIVIDE',
                     '.': 'PERIOD',
-                    '..': 'ELIPSIS',
+                    '..': 'ELLIPSIS',
                     '\\': 'BACKSLASH',
                     ':': 'COLON',
                     '%': 'PERCENT',

--- a/test/expressions/arrayIndex.js
+++ b/test/expressions/arrayIndex.js
@@ -48,16 +48,26 @@ describe("array index operator", function() {
         d1.innerHTML.should.equal("0,1,2,3")
     })
 
-    /*
     it ("can get the range of middle values in an array", function() {
-        var d1 = make(`<div id="d1" _="on click set var to [1,2,3,4,5] then put var[2 .. 3] as String into #d1"></div>`)
+        var d1 = make(`<div id="d1" _="on click set var to [0,1,2,3,4,5] then put var[2 .. 3] as String into #d1"></div>`)
         d1.click()
         d1.innerHTML.should.equal("2,3")
     })
-    */
+
+    it ("can get the range of middle values in an array WITHOUT EXTRA SPACES", function() {
+        var d1 = make(`<div id="d1" _="on click set var to [0,1,2,3,4,5] then put var[2..3] as String into #d1"></div>`)
+        d1.click()
+        d1.innerHTML.should.equal("2,3")
+    })
 
     it ("can get the range of last values in an array", function() {
-        var d1 = make(`<div id="d1" _="on click set var to [1,2,3,4,5] then put var[3..] as String into #d1"></div>`)
+        var d1 = make(`<div id="d1" _="on click set var to [0,1,2,3,4,5] then put var[3 ..] as String into #d1"></div>`)
+        d1.click()
+        d1.innerHTML.should.equal("3,4,5")
+    })
+
+    it ("can get the range of last values in an array WITHOUT EXTRA SPACES", function() {
+        var d1 = make(`<div id="d1" _="on click set var to [0,1,2,3,4,5] then put var[3..] as String into #d1"></div>`)
         d1.click()
         d1.innerHTML.should.equal("3,4,5")
     })

--- a/test/expressions/arrayIndex.js
+++ b/test/expressions/arrayIndex.js
@@ -42,6 +42,26 @@ describe("array index operator", function() {
         d1.innerHTML.should.equal("C");
     })
 
+    it ("can get the range of first values in an array", function() {
+        var d1 = make(`<div id="d1" _="on click set var to [0,1,2,3,4,5] then put var[..3] as String into #d1"></div>`)
+        d1.click()
+        d1.innerHTML.should.equal("0,1,2,3")
+    })
+
+    /*
+    it ("can get the range of middle values in an array", function() {
+        var d1 = make(`<div id="d1" _="on click set var to [1,2,3,4,5] then put var[2 .. 3] as String into #d1"></div>`)
+        d1.click()
+        d1.innerHTML.should.equal("2,3")
+    })
+    */
+
+    it ("can get the range of last values in an array", function() {
+        var d1 = make(`<div id="d1" _="on click set var to [1,2,3,4,5] then put var[3..] as String into #d1"></div>`)
+        d1.click()
+        d1.innerHTML.should.equal("3,4,5")
+    })
+
     it("errors when index exceeds array length", function () {
         var d1 = make("<div id='d1' _='on click set newVar to [10, 20, 30] then put newVar[10] into #d1.innerHTML'></div>");
         try {

--- a/test/expressions/arrayIndex.js
+++ b/test/expressions/arrayIndex.js
@@ -60,6 +60,12 @@ describe("array index operator", function() {
         d1.innerHTML.should.equal("2,3")
     })
 
+    it ("can get the range of middle values in an array using an expression", function() {
+        var d1 = make(`<div id="d1" _="on click set index to 3 then set var to [0,1,2,3,4,5] then put var[(index-1)..(index+1)] as String into #d1"></div>`)
+        d1.click()
+        d1.innerHTML.should.equal("2,3,4")
+    })
+
     it ("can get the range of last values in an array", function() {
         var d1 = make(`<div id="d1" _="on click set var to [0,1,2,3,4,5] then put var[3 ..] as String into #d1"></div>`)
         d1.click()

--- a/test/index.html
+++ b/test/index.html
@@ -110,6 +110,7 @@
 <script src="expressions/propertyAccess.js"></script>
 <script src="expressions/positionalExpression.js"></script>
 <script src="expressions/possessiveExpression.js"></script>
+<script src="expressions/arrayIndex.js"></script>
 
 <div id="mocha"></div>
 


### PR DESCRIPTION
This PR adds the area range notation that was requested on Discord.  Here are the formats supported:

```
set myVar to [0,1,2,3,4,5,6,7,8,9]
myVar[1] => 1
myVar[..4] => [0,1,2,3,4]
myVar[5..] => [5,6,7,8,9]
myVar[3..6] => [3,4,5,6]
```

This feature set *works* with one enormous caveat.  It seems like parsing numbers can break if they are immediately next to the ellipsis operator.  Without digging deeper, I suspect it may be because numbers can end with a period, which throws off the parser.  

To demonstrate this, I have made two sets of tests -- one that pass because an extra whitespace has been added into the range definitions like this `myVar[3 .. 6]`, and another that fails because the numbers are bunched together.

**Before we can merge this change** I'll need someone with more parsing experience to troubleshoot the problems I'm encountering with the parser, and update either my code, or the base-level library.