### PR TITLE
JSDoc Progress

### DIFF
--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -199,11 +199,13 @@
                  * @param {Token[]} tokens 
                  * @param {Token[]} consumed 
                  * @param {string} source 
-                 * @returns TokensObject
+                 * @returns {TokensObject}
                  */
                 function makeTokensObject(tokens, consumed, source) {
 
                     consumeWhitespace(); // consume initial whitespace
+
+                    /** @type Token | null */
                     var _lastConsumed = null;
 
                     function consumeWhitespace(){
@@ -222,7 +224,7 @@
 
                     /**
                      * @param {string} value 
-                     * @returns [Token]
+                     * @returns {Token}
                      */
                     function requireOpToken(value) {
                         var token = matchOpToken(value);
@@ -237,7 +239,7 @@
                      * @param {string} op1 
                      * @param {string} [op2]
                      * @param {string} [op3]
-                     * @returns [Token]
+                     * @returns {Token | void}
                      */
                     function matchAnyOpToken(op1, op2, op3) {
                         for (var i = 0; i < arguments.length; i++) {
@@ -253,7 +255,7 @@
                      * @param {string} op1
                      * @param {string} [op2]
                      * @param {string} [op3]
-                     * @returns [Token]
+                     * @returns {Token | void}
                      */
                      function matchAnyToken(op1, op2, op3) {
                         for (var i = 0; i < arguments.length; i++) {
@@ -267,7 +269,7 @@
 
                     /**
                      * @param {string} value 
-                     * @returns [Token]
+                     * @returns {Token | void}
                      */
                     function matchOpToken(value) {
                         if (currentToken() && currentToken().op && currentToken().value === value) {
@@ -277,10 +279,10 @@
 
                     /**
                      * @param {string} type1 
-                     * @param {string} type2 
-                     * @param {string} type3 
-                     * @param {string} type4 
-                     * @returns Token
+                     * @param {string} [type2] 
+                     * @param {string} [type3]
+                     * @param {string} [type4]
+                     * @returns {Token | void}
                      */
                     function requireTokenType(type1, type2, type3, type4) {
                         var token = matchTokenType(type1, type2, type3, type4);
@@ -293,10 +295,10 @@
 
                     /**
                      * @param {string} type1 
-                     * @param {string} type2 
-                     * @param {string} type3 
-                     * @param {string} type4 
-                     * @returns [Token]
+                     * @param {string} [type2]
+                     * @param {string} [type3]
+                     * @param {string} [type4]
+                     * @returns {Token | void}
                      */
                     function matchTokenType(type1, type2, type3, type4) {
                         if (currentToken() && currentToken().type && [type1, type2, type3, type4].indexOf(currentToken().type) >= 0) {
@@ -307,7 +309,7 @@
                     /**
                      * @param {string} value 
                      * @param {string} [type]
-                     * @returns Token
+                     * @returns {Token}
                      */
                     function requireToken(value, type) {
                         var token = matchToken(value, type);
@@ -321,7 +323,7 @@
                     /**
                      * @param {string} value 
                      * @param {string} [type]
-                     * @returns [Token]
+                     * @returns {Token | void}
                      */
                     function matchToken(value, type) {
                         var type = type || "IDENTIFIER";
@@ -331,7 +333,7 @@
                     }
 
                     /**
-                     * @returns Token
+                     * @returns {Token}
                      */
                     function consumeToken() {
                         var match = tokens.shift();
@@ -344,7 +346,7 @@
                     /**
                      * @param {string} value 
                      * @param {string} [type]
-                     * @returns Token[]
+                     * @returns {Token[]}
                      */
                     function consumeUntil(value, type) {
 
@@ -365,7 +367,7 @@
                     }
 
                     /**
-                     * @returns string
+                     * @returns {string}
                      */
                     function lastWhitespace() {
                         if (consumed[consumed.length - 1] && consumed[consumed.length - 1].type === "WHITESPACE") {
@@ -380,7 +382,7 @@
                     }
 
                     /**
-                     * @returns boolean
+                     * @returns {boolean}
                      */
                     function hasMore() {
                         return tokens.length > 0;
@@ -389,12 +391,10 @@
                     /**
                      * @param {number} n 
                      * @param {boolean} [dontIgnoreWhitespace]
-                     * @returns Token
+                     * @returns {Token}
                      */
                     function token(n, dontIgnoreWhitespace) {
-
-                        /** @type {Token} */
-                        var token;
+                        var /**@type {Token}*/ token;
                         var i = 0;
                         do {
                             if (!dontIgnoreWhitespace) {
@@ -417,25 +417,35 @@
                     }
 
                     /**
-                     * @returns Token
+                     * @returns {Token}
                      */
                     function currentToken() {
                         return token(0);
                     }
 
+                    /**
+                     * @returns {Token | null}
+                     */
                     function lastMatch() {
                         return _lastConsumed;
                     }
 
+                    /**
+                     * @returns {string}
+                     */
                     function sourceFor() {
                         return source.substring(this.startToken.start, this.endToken.end);
                     }
 
-                    function lineFor() {
+                    /**
+                     * @returns {string}
+                     */
+                     function lineFor() {
                         return source
                             .split("\n")[this.startToken.line - 1];
                     }
 
+                    /** @type {TokensObject} */
                     return {
                         matchAnyToken: matchAnyToken,
                         matchAnyOpToken: matchAnyOpToken,
@@ -461,6 +471,11 @@
                     }
                 }
 
+
+                /**
+                 * @param {Token[]} tokens 
+                 * @returns {boolean}
+                 */
                 function isValidSingleQuoteStringStart(tokens) {
                     if (tokens.length > 0) {
                         var previousToken = tokens[tokens.length - 1];
@@ -477,11 +492,10 @@
                 /**
                  * @param {string} string 
                  * @param {boolean} [template]
-                 * @returns TokensObject
+                 * @returns {TokensObject}
                  */
                 function tokenize(string, template) {
-                    /** @type Token[]*/
-                    var tokens = [];
+                    var tokens = /** @type {Token[]}*/ [];
                     var source = string;
                     var position = 0;
                     var column = 0;
@@ -538,7 +552,7 @@
                     /**
                      * @param {string} [type] 
                      * @param {string} [value]
-                     * @returns Token
+                     * @returns {Token}
                      */
                     function makeOpToken(type, value) {
                         var token = makeToken(type, value);
@@ -549,7 +563,7 @@
                     /**
                      * @param {string} [type]
                      * @param {string} [value]
-                     * @returns Token
+                     * @returns {Token}
                      */
                     function makeToken(type, value) {
                         return {
@@ -1107,8 +1121,10 @@
             //====================================================================
             // Runtime
             //====================================================================
+
+            /** @type ConversionMap */
             var CONVERSIONS = {
-                dynamicResolvers : [],
+                dynamicResolvers : /** @type DynamicConversionFunction[] */ [],
                 "String" : function(val){
                     if(val.toString){
                         return val.toString();
@@ -2010,7 +2026,7 @@
                             name: name,
                             value: value,
                             args: [value],
-                            op:function(context, value){
+                            op:function(_context, value){
                                 if (this.value) {
                                     return {name:this.name, value:value}
                                 } else {
@@ -2239,7 +2255,7 @@
                         time: time,
                         factor: factor,
                         args: [time],
-                        op: function (context, val) {
+                        op: function (_context, val) {
                             return val * this.factor
                         },
                         evaluate: function (context) {
@@ -2256,7 +2272,7 @@
                             root: root,
                             prop: prop,
                             args: [root],
-                            op:function(context, rootVal){
+                            op:function(_context, rootVal){
                                 var value = runtime.resolveProperty(rootVal, prop.value);
                                 return value;
                             },

--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -1008,7 +1008,7 @@
                 }
 
                 /**
-                 * @param {*} tokens 
+                 * @param {TokensObject} tokens 
                  * @param {string} message 
                  */
                 function raiseParseError(tokens, message) {
@@ -1021,7 +1021,7 @@
 
                 /**
                  * @param {TokensObject} tokens 
-                 * @returns 
+                 * @returns {GrammarElement}
                  */
                 function parseHyperScript(tokens) {
                     return parseElement("hyperscript", tokens)
@@ -3778,6 +3778,7 @@
                     var functionName = expr.root.name;
                     var functionArgs = expr.argExressions;
 
+                    /** @type {GrammarElement} */
                     var pseudoCommand = {
                         type: "pseudoCommand",
                         expr: expr,
@@ -3838,6 +3839,7 @@
                             root = target.root;
                         }
 
+                        /** @type {GrammarElement} */
                         var setCmd = {
                             target: target,
                             symbolWrite: symbolWrite,
@@ -3873,6 +3875,8 @@
                         if (tokens.hasMore()) {
                             tokens.requireToken("end");
                         }
+
+                        /** @type {GrammarElement} */
                         var ifCmd = {
                             expr: expr,
                             trueBranch: trueBranch,

--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -733,13 +733,13 @@
             /** @type ParserObject */
             var _parser = function () {
 
-                /** @type {Object<string,GrammarDefinition>} */ 
+                /** @type {Object<string,{GrammarDefinition}>} */ 
                 var GRAMMAR = {}
 
-                /** @type {Object<string,CommandDefinition>} */
+                /** @type {Object<string,{GrammarDefinition}>} */
                 var COMMANDS = {}
 
-                /** @type {Object<string,FeatureDefinition>} */
+                /** @type {Object<string,{GrammarDefinition}>} */
                 var FEATURES = {}
                 
                 var LEAF_EXPRESSIONS = [];
@@ -786,7 +786,7 @@
                  * @param {TokensObject} tokens 
                  * @param {string} [message]
                  * @param {*} [root]
-                 * @returns GrammarElement
+                 * @returns {GrammarElement}
                  */
                 function requireElement(type, tokens, message, root) {
                     var result = parseElement(type, tokens, root);
@@ -796,7 +796,7 @@
                 /**
                  * @param {string[]} types 
                  * @param {TokensObject} tokens 
-                 * @returns GrammarElement
+                 * @returns {GrammarElement}
                  */
                 function parseAnyOf(types, tokens) {
                     for (var i = 0; i < types.length; i++) {
@@ -818,7 +818,7 @@
 
                 /**
                  * @param {string} keyword 
-                 * @param {CommandDefinition} definition 
+                 * @param {GrammarDefinition} definition 
                  */
                 function addCommand(keyword, definition) {
                     var commandGrammarType = keyword + "Command";
@@ -839,12 +839,12 @@
 
                 /**
                  * @param {string} keyword 
-                 * @param {FeatureDefinition} definition 
+                 * @param {GrammarDefinition} definition 
                  */
                 function addFeature(keyword, definition) {
                     var featureGrammarType = keyword + "Feature";
 
-                    /** @type FeatureDefinition*/ 
+                    /** @type {GrammarDefinition} */ 
                     var featureDefinitionWrapper = function (parser, runtime, tokens) {
                         var featureElement = definition(parser, runtime, tokens);
                         if (featureElement) {
@@ -954,7 +954,7 @@
                                 } else {
                                     return root;
                                 }
-                            },
+                            }, 
                             execute: function(context) {
                                 return runtime.unifiedExec(this, context);
                             }
@@ -1057,9 +1057,10 @@
 
                 /**
                  * @param {TokensObject} tokens 
-                 * @returns 
+                 * @returns {(string | Token)[]}
                  */
                 function parseStringTemplate(tokens) {
+                    /** @type (string | Token)[] */
                     var returnArr = [""];
                     do {
                         returnArr.push(tokens.lastWhitespace());
@@ -1144,6 +1145,12 @@
                     }
                 }
             }
+
+            /********************************************
+             * RUNTIME OBJECT
+             ********************************************/
+
+            /** @type {RuntimeObject} */
             var _runtime = function () {
 
                 /**
@@ -1280,7 +1287,7 @@
                 var HALT = {halt_flag:true};
 
                 /**
-                 * @param {CommandDefinition} command 
+                 * @param {GrammarDefinition} command 
                  * @param {Context} ctx 
                  */
                 function unifiedExec(command,  ctx) {
@@ -1332,7 +1339,7 @@
                 /**
                  * @param {*} parseElement 
                  * @param {Context} ctx 
-                 * @returns 
+                 * @returns {*}
                  */
                 function unifiedEval(parseElement,  ctx) {
                     
@@ -1427,7 +1434,7 @@
 
                 /**
                  * @param {HTMLElement} elt 
-                 * @returns string
+                 * @returns {string | null}
                  */
                 function getScript(elt) {
                     for (var i = 0; i < getScriptAttributes().length; i++) {
@@ -1442,6 +1449,10 @@
                     return null;
                 }
 
+                /**
+                 * @param {Object} owner 
+                 * @param {Context} ctx 
+                 */
                 function addFeatures(owner, ctx) {
                     if(owner) {
                         if (owner.hyperscriptFeatures) {
@@ -1456,9 +1467,11 @@
                  * @param {*} feature 
                  * @param {*} hyperscriptTarget 
                  * @param {*} event 
-                 * @returns Context
+                 * @returns {Context}
                  */
                 function makeContext(owner, feature, hyperscriptTarget, event) {
+
+                    /** @type {Context} */
                     var ctx = {
                         meta: {
                             parser: _parser,
@@ -1489,9 +1502,9 @@
                 }
 
                 /**
-                 * @param {*} value 
+                 * @param {any} value 
                  * @param {string} type 
-                 * @returns any
+                 * @returns {any}
                  */
                 function convertValue(value,  type) {
 
@@ -1523,7 +1536,7 @@
 
                 /**
                  * @param {string} src 
-                 * @returns GrammarElement
+                 * @returns {GrammarElement}
                  */
                 function parse(src) {
                     var tokens = _lexer.tokenize(src);
@@ -1550,8 +1563,8 @@
 
                 /**
                  * @param {string} src 
-                 * @param {*} ctx 
-                 * @returns 
+                 * @param {Context} ctx 
+                 * @returns {any}
                  */
                 function evaluate(src, ctx) {
                     ctx = mergeObjects(makeContext(document.body, null,
@@ -1616,7 +1629,7 @@
 
                 /**
                  * @param {HTMLElement} elt 
-                 * @returns Object<string,any>
+                 * @returns {Object}
                  */
                 function getInternalData(elt) {
                     var dataProp = 'hyperscript-internal-data';
@@ -1631,7 +1644,7 @@
                  * @param {any} value 
                  * @param {string} typeString 
                  * @param {boolean} [nullOk]
-                 * @returns 
+                 * @returns {boolean}
                  */
                 function typeCheck(value, typeString, nullOk) {
                     if (value == null && nullOk) {
@@ -1644,7 +1657,7 @@
                 /**
                  * @param {string} str 
                  * @param {Context} context 
-                 * @returns any
+                 * @returns {any}
                  */
                 function resolveSymbol(str, context) {
                     if (str === "me" || str === "my" || str === "I") {
@@ -1668,9 +1681,9 @@
                 }
 
                 /**
-                 * @param {Command} command 
+                 * @param {GrammarElement} command 
                  * @param {Context} context 
-                 * @returns 
+                 * @returns {undefined | GrammarElement}
                  */
                 function findNext(command, context) {
                     if (command) {
@@ -1687,7 +1700,7 @@
                 /**
                  * @param {Object<string,any>} root 
                  * @param {string} property 
-                 * @returns any
+                 * @returns {any}
                  */
                 function resolveProperty(root, property, attribute) {
                     if (root != null) {
@@ -1783,9 +1796,8 @@
                 }
 
                 /**
-                 * 
                  * @param {string} str 
-                 * @returns string
+                 * @returns {string}
                  */
                 function escapeSelector(str) {
                     return str.replace(/:/g, function(str){
@@ -1793,6 +1805,10 @@
                     });
                 }
 
+                /**
+                 * @param {any} value 
+                 * @param {*} elt 
+                 */
                 function nullCheck(value, elt) {
                     if (value == null) {
                         throw new Error(elt.sourceFor() + " is null");
@@ -1801,14 +1817,16 @@
 
                 /**
                  * @param {any} value 
-                 * @returns boolean
+                 * @returns {boolean}
                  */
                 function isEmpty(value) {
                     return (value == undefined) || (value.length === 0);
                 }
 
-                var hyperscriptUrl = 'document' in globalScope ? document.currentScript.src : null
+                /** @type string | null */
+                var hyperscriptUrl = ('document' in globalScope) ? document.currentScript.src : null
 
+                /** @type {RuntimeObject} */
                 return {
                     typeCheck: typeCheck,
                     forEach: forEach,

--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -1700,6 +1700,7 @@
                 /**
                  * @param {Object<string,any>} root 
                  * @param {string} property 
+                 * @param {boolean} attribute
                  * @returns {any}
                  */
                 function resolveProperty(root, property, attribute) {
@@ -1707,19 +1708,19 @@
                         var val = attribute && root.getAttribute ? root.getAttribute(property) : root[property];
                         if (typeof val !== 'undefined') {
                             return val;
-                        } else {
-                            if (isArrayLike(root)) {
-                                // flat map
-                                var result = [];
-                                for (var i = 0; i < root.length; i++) {
-                                    var component = root[i];
-                                    var componentValue = attribute ? component.getAttribute(property) : component[property];
-                                    if (componentValue) {
-                                        result.push(componentValue);
-                                    }
+                        } 
+
+                        if (isArrayLike(root)) {
+                            // flat map
+                            var result = [];
+                            for (var i = 0; i < root.length; i++) {
+                                var component = root[i];
+                                var componentValue = attribute ? component.getAttribute(property) : component[property];
+                                if (componentValue) {
+                                    result.push(componentValue);
                                 }
-                                return result;
                             }
+                            return result;
                         }
                     }
                 }

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -75,27 +75,27 @@
  * PARSER *************************
  * 
  * @typedef ParserObject
- * @property {*} setParent
+ * @property {(elt:GrammarElement, parent:GrammarElement) => void} setParent
  * @property {(type:string, tokens:TokensObject, message?:string, root?:any) => GrammarElement} requireElement
- * @property {*} parseElement
- * @property {*} featureStart
- * @property {*} commandStart
- * @property {*} commandBoundary
+ * @property {(type:string, tokens:TokensObject, root?:any) => GrammarElement | void} parseElement
+ * @property {(token:Token) => GrammarDefinition} featureStart
+ * @property {(token:Token) => GrammarDefinition} commandStart
+ * @property {(token:Token) => boolean} commandBoundary
  * @property {(types:string[], tokens:TokensObject) => GrammarElement} parseAnyOf
- * @property {*} parseHyperScript
- * @property {*} raiseParseError
+ * @property {(tokens:TokensObject) => GrammarElement | void} parseHyperScript
+ * @property {(tokens:TokensObject, message:string) => void} raiseParseError
  * @property {(name:string, definition:GrammarDefinition) => void} addGrammarElement
  * @property {(name:string, definition:GrammarDefinition) => void} addCommand
  * @property {(name:string, definition:GrammarDefinition) => void} addFeature
  * @property {(name:string, definition:GrammarDefinition) => void} addLeafExpression
  * @property {(name:string, definition:GrammarDefinition) => void} addIndirectExpression
  * @property {(tokens:TokensObject) => (string | Token)[] } parseStringTemplate
- * 
- * @typedef {(parser:ParserObject, runtime:RuntimeObject, tokens:TokensObject, root:any) => GrammarElement} GrammarDefinition
  *
- * @typedef {Object} GrammarElement
- * @property {string} type
- * @property {(context:Context) => any} evaluate
+ * @typedef GrammarElement
+ * @property {string} [type]
+ * @property {any[]} [args]
+ * @property {(ctx:Context, root:*, ...args:any) => GrammarElement} [op]
+ * @property {(context:Context) => any} [evaluate]
  * @property {GrammarElement} [parent]
  * @property {GrammarElement} [next]
  * @property {(context:Context) => GrammarElement} [resolveNext]
@@ -103,6 +103,12 @@
  * @property {() => void} [install]
  * @property {(context:Context) => void} [execute]
  * 
+ * @callback GrammarDefinition
+ * @param {ParserObject} parser
+ * @param {RuntimeObject} runtime
+ * @param {TokensObject} tokens 
+ * @param {*} root
+ * @returns {GrammarElement | void}
  * 
  * RUNTIME **********************
  * 

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -10,17 +10,17 @@
  * PUBLIC API
  * @typedef HyperscriptObject
  * @property {HyperscriptInternalsObject} internals
- * @property {(keyword:string, definition:GrammarDefinition) => any } addFeature
- * @property {(keyword:string, definition:GrammarDefinition) => any } addCommand
- * @property {(keyword:string, definition:GrammarDefinition) => any } addLeafExpression
- * @property {(keyword:string, definition:GrammarDefinition) => any } addIndirectExpression
+ * @property {(keyword:string, definition:GrammarDefinition) => void | GrammarElement } addFeature
+ * @property {(keyword:string, definition:GrammarDefinition) => void | GrammarElement } addCommand
+ * @property {(keyword:string, definition:GrammarDefinition) => void | GrammarElement } addLeafExpression
+ * @property {(keyword:string, definition:GrammarDefinition) => void | GrammarElement } addIndirectExpression
  * @property {(str:string, ctx:Context) => *} evaluate
  * @property {(str:string) => *} parse
  * @property {(elt:HTMLElement) => void} processNode
  * @property {HyperscriptConfigObject} config
  * 
  * @typedef HyperscriptInternalsObject
- * @property {*} lexer
+ * @property {LexerObject} lexer
  * @property {ParserObject} parser
  * @property {RuntimeObject} runtime
  * 
@@ -40,21 +40,21 @@
  * @property {(tokens:Token[], consumed:Token[], source:string) => TokensObject} makeTokensObject
  * 
  * @typedef TokensObject
- * @property {(token:string) => undefined | Token} matchAnyToken
- * @property {(token:string) => undefined | Token} matchAnyOpToken
- * @property {(token:string) => undefined | Token} matchOpToken
+ * @property {(type1:string, type2?:string, type3?:string, type4?:string) => Token | void} matchTokenType
+ * @property {(token:string) => Token | void} matchToken
+ * @property {(token:string) => Token | void} matchAnyToken
+ * @property {(token:string) => Token | void} matchAnyOpToken
+ * @property {(token:string) => Token | void} matchOpToken
+ * @property {(type1:string, type2?:string, type3?:string, type4?:string) => Token} requireTokenType
  * @property {(token:string) => Token} requireOpToken
- * @property {(token:string) => undefined | Token} matchTokenType
- * @property {(token:string) => Token} requireTokenType
- * @property {() => Token} consumeToken
- * @property {(token:string) => undefined | Token} matchToken
  * @property {(token:string) => Token} requireToken
- * @property {*} list
- * @property {*} consumed
- * @property {*} source
- * @property {*} hasMore
+ * @property {() => Token} consumeToken
+ * @property {Token[]} list
+ * @property {Token[]} consumed
+ * @property {string} source
+ * @property {() => boolean} hasMore
  * @property {() => Token} currentToken
- * @property {*} lastMatch
+ * @property {() => Token | null} lastMatch
  * @property {(n:number, dontIgnoreWhitespace?:boolean) => Token} token
  * @property {(value:string, type?:string) => Token[]} consumeUntil
  * @property {() => Token[]} consumeUntilWhitespace
@@ -89,7 +89,7 @@
  * @property {(name:string, definition:GrammarDefinition) => void} addFeature
  * @property {(name:string, definition:GrammarDefinition) => void} addLeafExpression
  * @property {(name:string, definition:GrammarDefinition) => void} addIndirectExpression
- * @property {(TokensObject) => (string | Token)[] } parseStringTemplate
+ * @property {(tokens:TokensObject) => (string | Token)[] } parseStringTemplate
  * 
  * @typedef {(parser:ParserObject, runtime:RuntimeObject, tokens:TokensObject, root:any) => GrammarElement} GrammarDefinition
  *
@@ -118,15 +118,15 @@
  * @property {() => string } getScriptSelector
  * @property {(str:string, ctx:Context) => any } resolveSymbol
  * @property {(owner:*, feature:*, hyperscriptTarget:*, event:*) => Context } makeContext
- * @property {(command:GrammarElement, ctx:Context) => undefined | GrammarElement } findNext
+ * @property {(command:GrammarElement, ctx:Context) => GrammarElement | undefined } findNext
  * @property {(parseElement:*, ctx:Context) => * } unifiedEval
  * @property {(value:any, type:string) => any } convertValue
  * @property {(command: GrammarDefinition, ctx:Context) => void } unifiedExec
- * @property {(root:Object<string,any>, property:string) => any } resolveProperty
- * @property {(namespace:string[], name:string, value:any) => void } assignToNamespace
+ * @property {(root:Object<string,any>, property:string, attribute:boolean) => any } resolveProperty
+ * @property {(elt:Element, namespace:string[], name:string, value:any) => void } assignToNamespace
  * @property {() => void } registerHyperTrace
  * @property {() => void } getHyperTrace
- * @property {() => void } getInternalData
+ * @property {(elt:HTMLElement) => Object } getInternalData
  * @property {(str:string) => string } escapeSelector
  * @property {(value:any, elt:*) => void } nullCheck
  * @property {(value:any) => boolean} isEmpty
@@ -149,4 +149,12 @@
  * @property {*} feature
  * @property {*} iterators
  * @property {ContextMetaData} ctx
+ * 
+ * 
+ * @typedef {Object<string,ConversionFunction>} ConversionMap
+ * @property {DynamicConversionFunction[]} dynamicResolvers
+ * 
+ * @typedef {(value:any) => any} ConversionFunction
+ * @typedef {(conversionName:string, value:any) => any} DynamicConversionFunction
+ * 
  */


### PR DESCRIPTION
This PR includes more progress on the JSDoc project.  There are still plenty of "compiler warnings" due to incompletely defined types, but it's coming together pretty nicely.  As always, all automated tests are passing.

These changes are *mostly* documentation only, but there are a few minor formatting/style changes as well, included because they were making the Typescript validator complain.  For instance, it doesn't like when we overwrite a variable of one type with a new value of a different type.  This is fixed by choosing a new variable name for the other type.  I also removed a small number of redundant "else" statements that appear after a "return" -- this shortens the code by a tiny amount, and reduces the overall code complexity.  Hopefully this is considered a win :)