### PR TITLE
Increment / Decrement commands

### DIFF
--- a/test/commands/increment.js
+++ b/test/commands/increment.js
@@ -1,0 +1,101 @@
+describe("the increment command", function() {
+
+    beforeEach(function () {
+        clearWorkArea();
+    });
+    afterEach(function () {
+        clearWorkArea();
+    });
+
+    it("can increment an empty variable", function () {
+        var div = make(`<div _="on click increment value then put value into me"></div>`);
+        div.click()
+        div.innerHTML.should.equal("1")
+    });
+
+    it("can increment a variable", function () {
+        var div = make(`<div _="on click set value to 20 then increment value by 2 then put value into me"></div>`);
+        div.click()
+        div.innerHTML.should.equal("22")
+    });
+
+    it("can increment an attribute", function () {
+        var div = make(`<div value="5" _="on click increment @value then put @value into me"></div>`);
+        div.click()
+        div.click()
+        div.click()
+        div.innerHTML.should.equal("8")
+    });
+
+    it("can increment an floating point numbers", function () {
+        var div = make(`<div value="5" _="on click set value to 5.2 then increment value by 6.1 then put value into me"></div>`);
+        div.click()
+        div.innerHTML.should.equal("11.3")
+    });
+
+    it("can increment a property", function () {
+        var div = make(`<div _="on click increment my.innerHTML">3</div>`);
+        div.click()
+        div.click()
+        div.click()
+        div.innerHTML.should.equal("6")
+
+    });
+
+    it("can increment a value multiple times", function () {
+        var div = make(`<div _="on click increment my.innerHTML"></div>`);
+        div.click()
+        div.click()
+        div.click()
+        div.click()
+        div.click()
+        div.innerHTML.should.equal("5")
+    })
+
+    it("can decrement an empty variable", function () {
+        var div = make(`<div _="on click decrement value then put value into me"></div>`);
+        div.click()
+        div.innerHTML.should.equal("-1")
+    });
+
+    it("can decrement a variable", function () {
+        var div = make(`<div _="on click set value to 20 then decrement value by 2 then put value into me"></div>`);
+        div.click()
+        div.innerHTML.should.equal("18")
+    });
+
+    it("can decrement an attribute", function () {
+        var div = make(`<div value="5" _="on click decrement @value then put @value into me"></div>`);
+        div.click()
+        div.click()
+        div.click()
+        div.innerHTML.should.equal("2")
+    });
+
+    it("can decrement an floating point numbers", function () {
+        var div = make(`<div value="5" _="on click set value to 6.1 then decrement value by 5.1 then put value into me"></div>`);
+        div.click()
+        div.innerHTML.should.equal("1")
+    });
+
+    it("can decrement a property", function () {
+        var div = make(`<div _="on click decrement my.innerHTML">3</div>`);
+        div.click()
+        div.click()
+        div.click()
+        div.innerHTML.should.equal("0")
+
+    });
+
+    it("can decrement a value multiple times", function () {
+        var div = make(`<div _="on click decrement my.innerHTML"></div>`);
+        div.click()
+        div.click()
+        div.click()
+        div.click()
+        div.click()
+        div.innerHTML.should.equal("-5")
+    })
+
+});
+

--- a/test/index.html
+++ b/test/index.html
@@ -86,6 +86,7 @@
 <script src="commands/tell.js"></script>
 <script src="commands/settle.js"></script>
 <script src="commands/unlessModifier.js"></script>
+<script src="commands/increment.js"></script>
 
 <!-- expressions -->
 <script src="expressions/attributeExpression.js"></script>


### PR DESCRIPTION
This PR adds increment / decrement commands to hyperscript.

* It allows `increment <variable> by <amount>` so that you 
* The amount defaults to 1, so that `increment <variable>` just adds one to the value.
* It parses variables as a floating point number, so that `increment <variable that's 5.2> by 1.3` correctly sets the value to 6.5
* It uses `makeSetter()` function, so it works with properties, attributes, and object references
* If a value is not present, it assumes zero, and increments/decrements from there.