### PR TITLE
Fix code syntax for Exceptions example in docs.md

### DIFF
--- a/www/docs.md
+++ b/www/docs.md
@@ -516,6 +516,7 @@ namespace, rather than polluting the global namespace:
 A function may have one and only one catch block associated with it, in which to handle exceptions that occur
 during the execution of the body:
 
+```html
 <script type="text/hyperscript">
   def example
     call mightThrowAnException()
@@ -523,6 +524,7 @@ during the execution of the body:
     log e
   end
 </script>
+```
 
 ### <a name="behaviors"></a>[Behaviors](#behaviors)
 


### PR DESCRIPTION
Currently the Markdown code formatting syntax is missing from the Exceptions example in docs.md, so the example is being filtered out as a literal script tag:

![Screen Shot 2021-04-21 at 2 08 07 PM](https://user-images.githubusercontent.com/18020/115600805-0f9d3380-a2ab-11eb-9df5-426cf26caaf8.png)
