### PR TITLE
Allow fetch to use custom conversions

### DIFF
--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -1201,6 +1201,7 @@
                     return parseFloat(val);
                 },
                 "Number" : function(val){
+                console.log(val)
                     return Number(val);
                 },
                 "Date" : function(val){
@@ -4543,6 +4544,7 @@
                         var args = parser.parseElement("objectLiteral", tokens);
 
                         var type = "text";
+                        var conversion;
                         if (tokens.matchToken("as")) {
                             if (tokens.matchToken("json")) {
                                 type = "json";
@@ -4550,14 +4552,14 @@
                                 type = "response";
                             } else if (tokens.matchToken("text")) {
                             } else {
-                                parser.raiseParseError(tokens, "Unknown response type: " + tokens.currentToken());
+                              conversion = parser.requireElement('dotOrColonPath', tokens).evaluate();
                             }
                         }
 
                         /** @type {GrammarElement} */
                         var fetchCmd = {
                             url:url,
-                            argExrepssions:args,
+                            argExpressions:args,
                             args: [url, args],
                             op: function (context, url, args) {
                                 return new Promise(function (resolve, reject) {
@@ -4573,6 +4575,7 @@
                                                 })
                                             } else {
                                                 value.text().then(function (result) {
+                                                    if (conversion) result = runtime.convertValue(result, conversion);
                                                     context.result = result;
                                                     resolve(runtime.findNext(fetchCmd, context));
                                                 })

--- a/test/commands/fetch.js
+++ b/test/commands/fetch.js
@@ -61,6 +61,20 @@ describe("the fetch command", function() {
         }, 50);
     })
 
+    
+    it("can do a simple fetch w/ a custom conversion", function(done){
+        window.fetch.returns(Promise.resolve(new window.Response("1.2000", {
+            status: 200,
+            headers: {'Content-type': 'text/plain'}
+        })));
+        var div = make("<div _='on click fetch /test as Number then put it into my.innerHTML'></div>");
+        div.click();
+        setTimeout(function () {
+            div.innerHTML.should.equal("1.2");
+            done();
+        }, 50);
+    })
+
     it("can do a simple post", function(done){
         window.fetch.returns(Promise.resolve(new window.Response("yay", {
             status: 200,


### PR DESCRIPTION
If the `as ...` clause is not text, response of json, it will be parsed as a [conversion](https://dev.hyperscript.org/expressions/as/).