### PR TITLE
"as Fragment": Conversion to parse HTML

### DIFF
--- a/src/lib/web.js
+++ b/src/lib/web.js
@@ -1030,4 +1030,17 @@
 
 		return toHTML(value);
 	}
+
+	_hyperscript.config.conversions["Fragment"] = function (val) {
+		var frag = document.createDocumentFragment();
+		_hyperscript.internals.runtime.forEach(val, function (val) {
+			if (val instanceof Node) frag.append(val);
+			else {
+				var temp = document.createElement("template");
+				temp.innerHTML = val;
+				frag.append(temp.content);
+			}
+		})
+		return frag;
+	}
 })()

--- a/test/expressions/asExpression.js
+++ b/test/expressions/asExpression.js
@@ -245,6 +245,31 @@ describe("as operator", function() {
         result.should.equal("123");
     })
 
+    it("converts strings into fragments", function () {
+        var value = "<p></p>"
+
+        var result = evalHyperScript("value as Fragment", {value: value});
+        result.childElementCount.should.equal(1);
+        result.firstChild.tagName.should.equal("P");
+    })
+
+    it("converts elements into fragments", function () {
+        var value = document.createElement("p")
+
+        var result = evalHyperScript("value as Fragment", {value: value});
+        result.childElementCount.should.equal(1);
+        result.firstChild.tagName.should.equal("P");
+    })
+
+    it("converts arrays into fragments", function () {
+        var value = [document.createElement("p"), "<p></p>"]
+
+        var result = evalHyperScript("value as Fragment", {value: value});
+        result.childElementCount.should.equal(2);
+        result.firstChild.tagName.should.equal("P");
+        result.lastChild.tagName.should.equal("P");
+    })
+
     it("can accept custom comversions", function () {
         _hyperscript.config.conversions["Foo"] = function(val){
             return "foo" + val;


### PR DESCRIPTION
This conversion converts strings, elements and arrays thereof into DocumentFragment.