### PR TITLE
www: Remove repeated title and layout from frontmatter

### DIFF
--- a/www/_data/layout.json
+++ b/www/_data/layout.json
@@ -1,0 +1,1 @@
+"layout.njk"

--- a/www/_includes/layout.njk
+++ b/www/_includes/layout.njk
@@ -1,6 +1,10 @@
+---
+title: ///_hyperscript
+---
+
 <html lang="en">
 <head>
-    <title>///_hyperscript</title>
+    <title>{{ title }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="/css/site.css"/>
     <link rel="stylesheet" href="/css/prism-htmx.css"/>

--- a/www/commands/add.md
+++ b/www/commands/add.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `add` Command
 

--- a/www/commands/append.md
+++ b/www/commands/append.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `append` Command
 

--- a/www/commands/async.md
+++ b/www/commands/async.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `async` Command
 

--- a/www/commands/call.md
+++ b/www/commands/call.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `call` Command
 

--- a/www/commands/decrement.md
+++ b/www/commands/decrement.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `decrement` Command
 

--- a/www/commands/default.md
+++ b/www/commands/default.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `default` Command
 

--- a/www/commands/fetch.md
+++ b/www/commands/fetch.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `fetch` Command
 

--- a/www/commands/go.md
+++ b/www/commands/go.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `go` Command
 

--- a/www/commands/halt.md
+++ b/www/commands/halt.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `halt` Command
 

--- a/www/commands/hide.md
+++ b/www/commands/hide.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `hide` Command
 

--- a/www/commands/if.md
+++ b/www/commands/if.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `if` Command
 

--- a/www/commands/increment.md
+++ b/www/commands/increment.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `increment` Command
 

--- a/www/commands/js.md
+++ b/www/commands/js.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `js` Command (inline)
 

--- a/www/commands/log.md
+++ b/www/commands/log.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `log` Command
 

--- a/www/commands/measure.md
+++ b/www/commands/measure.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `measure` Command
 

--- a/www/commands/pseudo-commands.md
+++ b/www/commands/pseudo-commands.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## Pseudo-Commands
 

--- a/www/commands/put.md
+++ b/www/commands/put.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `put` Command
 

--- a/www/commands/remove.md
+++ b/www/commands/remove.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `remove` Command
 

--- a/www/commands/render.md
+++ b/www/commands/render.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `render` command
 

--- a/www/commands/repeat.md
+++ b/www/commands/repeat.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `repeat` Command
 

--- a/www/commands/return.md
+++ b/www/commands/return.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `return` Command
 

--- a/www/commands/send.md
+++ b/www/commands/send.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `send` Command
 

--- a/www/commands/set.md
+++ b/www/commands/set.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `set` Command
 

--- a/www/commands/settle.md
+++ b/www/commands/settle.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `settle` Command
 

--- a/www/commands/show.md
+++ b/www/commands/show.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `show` Command
 

--- a/www/commands/take.md
+++ b/www/commands/take.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `take` Command
 

--- a/www/commands/tell.md
+++ b/www/commands/tell.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `tell` Command
 

--- a/www/commands/throw.md
+++ b/www/commands/throw.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `throw` Command
 

--- a/www/commands/toggle.md
+++ b/www/commands/toggle.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `toggle` Command
 

--- a/www/commands/transition.md
+++ b/www/commands/transition.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `transition` Command
 

--- a/www/commands/trigger.md
+++ b/www/commands/trigger.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `trigger` Command
 

--- a/www/commands/wait.md
+++ b/www/commands/wait.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `wait` Command
 

--- a/www/comparison.md
+++ b/www/comparison.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"
   integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4="

--- a/www/cookbook.md
+++ b/www/cookbook.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 # The hyperscript Cookbook
 

--- a/www/docs.md
+++ b/www/docs.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 <div class="row">
 <div class="2 col nav">

--- a/www/expressions.md
+++ b/www/expressions.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 <div class="row">
 <div class="2 col nav">

--- a/www/expressions/as.md
+++ b/www/expressions/as.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `as` Expression
 

--- a/www/expressions/async.md
+++ b/www/expressions/async.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `attribute reference` Expression
 

--- a/www/expressions/attribute-ref.md
+++ b/www/expressions/attribute-ref.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `attribute reference` Expression
 

--- a/www/expressions/block-literal.md
+++ b/www/expressions/block-literal.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `block literal` Expression
 

--- a/www/expressions/class-reference.md
+++ b/www/expressions/class-reference.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `class reference` Expression
 

--- a/www/expressions/closest.md
+++ b/www/expressions/closest.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `closest` Expression
 

--- a/www/expressions/comparison-operator.md
+++ b/www/expressions/comparison-operator.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `comparison operator` Expression
 

--- a/www/expressions/id-reference.md
+++ b/www/expressions/id-reference.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `id reference` Expression
 

--- a/www/expressions/logical-operator.md
+++ b/www/expressions/logical-operator.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `logical operator` Expression
 

--- a/www/expressions/no.md
+++ b/www/expressions/no.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `no` Expression
 

--- a/www/expressions/of.md
+++ b/www/expressions/of.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `of` Expression
 

--- a/www/expressions/positional.md
+++ b/www/expressions/positional.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `positional` Expressions
 

--- a/www/expressions/possessive.md
+++ b/www/expressions/possessive.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `possessive` Expression
 

--- a/www/expressions/query-reference.md
+++ b/www/expressions/query-reference.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `query reference` Expression
 

--- a/www/expressions/string.md
+++ b/www/expressions/string.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `string` Expression
 

--- a/www/expressions/time-expression.md
+++ b/www/expressions/time-expression.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `time` Expression
 

--- a/www/features/behavior.md
+++ b/www/features/behavior.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `behavior` feature 
 

--- a/www/features/def.md
+++ b/www/features/def.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `def` Feature
 

--- a/www/features/event-source.md
+++ b/www/features/event-source.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript #_
----
 
 ## The `eventsource` feature
 

--- a/www/features/init.md
+++ b/www/features/init.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `init` Feature
 

--- a/www/features/js.md
+++ b/www/features/js.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `js` Feature (top-level)
 

--- a/www/features/on.md
+++ b/www/features/on.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## The `event handler` Feature
 

--- a/www/features/socket.md
+++ b/www/features/socket.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript #_
----
 
 ## The `socket` feature
 

--- a/www/features/worker.md
+++ b/www/features/worker.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript #_
----
 
 ## The `worker` feature
 

--- a/www/hdb.md
+++ b/www/hdb.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 # HDB: the _hyperscript debugger
 

--- a/www/index.md
+++ b/www/index.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 <div style="background-color: lightgoldenrodyellow; margin: 16px; border-radius: 8px;
             color: darkgoldenrod; border: gold 1px solid; font-size: 20px">

--- a/www/light.md
+++ b/www/light.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 <div class="hero light full-width">
 <div class="c">

--- a/www/posts/2021-02-28-hyperscript-0.0.4-is-released.md
+++ b/www/posts/2021-02-28-hyperscript-0.0.4-is-released.md
@@ -1,5 +1,4 @@
 ---
-layout: layout.njk
 tags: post
 title: hyperscript 0.0.4 has been released!
 date: 2021-02-28

--- a/www/posts/2021-03-06-hyperscript-0.0.5-is-released.md
+++ b/www/posts/2021-03-06-hyperscript-0.0.5-is-released.md
@@ -1,5 +1,4 @@
 ---
-layout: layout.njk
 tags: post
 title: hyperscript 0.0.5 has been released!
 date: 2021-03-06

--- a/www/posts/2021-03-16-hyperscript-0.0.6-is-released.md
+++ b/www/posts/2021-03-16-hyperscript-0.0.6-is-released.md
@@ -1,5 +1,4 @@
 ---
-layout: layout.njk
 tags: post
 title: hyperscript 0.0.6 has been released!
 date: 2021-03-16

--- a/www/posts/2021-03-21-hyperscript-0.0.8-is-released.md
+++ b/www/posts/2021-03-21-hyperscript-0.0.8-is-released.md
@@ -1,5 +1,4 @@
 ---
-layout: layout.njk
 tags: post
 title: hyperscript 0.0.8 has been released!
 date: 2021-03-21

--- a/www/posts/2021-04-05-hyperscript-0.0.9-is-released.md
+++ b/www/posts/2021-04-05-hyperscript-0.0.9-is-released.md
@@ -1,5 +1,4 @@
 ---
-layout: layout.njk
 tags: post
 title: hyperscript 0.0.9 has been released!
 date: 2021-04-05

--- a/www/posts/2021-04-06-aysnc-transparency-in-practice.md
+++ b/www/posts/2021-04-06-aysnc-transparency-in-practice.md
@@ -1,5 +1,4 @@
 ---
-layout: layout.njk
 tags: post
 title: async transparency in practice
 date: 2021-04-06

--- a/www/reference.md
+++ b/www/reference.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## <a name='features'></a>[Features](#features)
 

--- a/www/talk.md
+++ b/www/talk.md
@@ -1,7 +1,3 @@
----
-layout: layout.njk
-title: ///_hyperscript
----
 
 ## hyperscript Talk
 


### PR DESCRIPTION
Currently, almost all source files for the website start as such:

```yaml
---
layout: layout.njk
title: ///_hyperscript
---
```

In this PR:
- The layout was moved to a [global data file][].
- The title was placed in the frontmatter of layout.njk, and can be overridden thanks to the [data cascade][].

[global data file]: https://www.11ty.dev/docs/data-global/
[data cascade]: https://www.11ty.dev/docs/data-cascade/