### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 _site
 /HyperTalk Reference 2.4.pdf
 .DS_Store
+*.icloud


### PR DESCRIPTION
Sets Git to ignore the `*.icloud` files automatically added into the directory by MacOS.