### PR TITLE
syntax: changed request to response

### DIFF
--- a/www/commands/fetch.md
+++ b/www/commands/fetch.md
@@ -4,7 +4,7 @@
 ### Syntax
 
 ```ebnf
-fetch <stringLike> [<object literal>] [ as ( json | text | request ) ]
+fetch <stringLike> [<object literal>] [ as ( json | text | response ) ]
 ```
 
 ### Description
@@ -13,8 +13,8 @@ The `fetch` command issues a [fetch](https://developer.mozilla.org/en-US/docs/We
 given URL. The URL can either be a naked URL or a string literal.
 
 By default the result will be processed as text, but you can have it processed
-as JSON, as HTML, or as a raw request object by adding the `as json`, `as html`
-or `as request` modifiers.
+as JSON, as HTML, or as a raw response object by adding the `as json`, `as html`
+or `as response` modifiers.
 
 Additionally, you can use [conversions](/expressions/as) directly on the
 response text.


### PR DESCRIPTION
The docs are not up todate to the syntax of fetch: you'll have to use the conversion `as response` to get the response object. The docs state `as request`.