### PR TITLE
fix missing 'url' in example code of go command docs

### DIFF
--- a/www/commands/go.md
+++ b/www/commands/go.md
@@ -24,7 +24,7 @@ Finally, the `go back` form will navigate back in the history stack.
 ### Examples
 
 ```html
-<button _="on click go to https://duck.com">
+<button _="on click go to url https://duck.com">
   Go Search
 </button>
 


### PR DESCRIPTION
Example code doesn't work as it was missing a 'url' inside it. Small fix in docs.