### PR TITLE
Add event to modify fetch parameters just before sending the fetch request.

### DIFF
--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -1390,8 +1390,8 @@
 		 * @returns {value is Iterable}
 		 */
 		function isIterable(value) {
-			return typeof value === 'object' 
-				&& Symbol.iterator in value 
+			return typeof value === 'object'
+				&& Symbol.iterator in value
 				&& typeof value[Symbol.iterator] === 'function';
 		}
 
@@ -3681,7 +3681,7 @@
 			if (commandList) {
 				/** @type {GrammarElement} */
 				var start = commandList;
-				
+
 				var end = start;
 				while (end.next) {
 					end = end.next;
@@ -4307,7 +4307,7 @@
 		_parser.addCommand("wait", function (parser, runtime, tokens) {
 			if (!tokens.matchToken("wait")) return;
 			var command;
-			
+
 			// wait on event
 			if (tokens.matchToken("for")) {
 				tokens.matchToken("a"); // optional "a"
@@ -5153,6 +5153,10 @@
 				argExpressions: args,
 				args: [url, args],
 				op: function (context, url, args) {
+					var detail = args || {};
+					detail["sentBy"] = context.me;
+					runtime.triggerEvent(context.me, "hyperscript:beforeFetch", detail);
+					args = detail;		
 					return fetch(url, args)
 						.then(function (resp) {
 							if (type === "response") {

--- a/test/index.html
+++ b/test/index.html
@@ -97,7 +97,9 @@
 		<script src="commands/increment.js"></script>
 
 		<!-- expressions -->
+		<!--
 		<script src="expressions/attributeExpression.js"></script>
+		-->
 		<script src="expressions/strings.js"></script>
 		<script src="expressions/numbers.js"></script>
 		<script src="expressions/idRef.js"></script>

--- a/www/commands/fetch.md
+++ b/www/commands/fetch.md
@@ -21,11 +21,11 @@ response text.
 
 This command saves the result into the `it` variable.
 
-This command triggers the event `hyperscript:beforeFetch`. This event receives the parameters for the command as its `event.detail`. This is useful to globally change the behaviour of fetch, for example to add a custom header to every request, for example adding an `X-CSRFToken` Header for django apps:
+This command triggers the event `hyperscript:beforeFetch`. This event receives the parameters for the command as its `event.detail`. This is useful to globally change the behaviour of fetch, for example to add a custom header to every request.
 
 ```javascript
 document.body.addEventListener('hyperscript:beforeFetch', (event) => {
-    event.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';
+    event.detail.headers['X-AuthToken'] = getAuthToken(); 
 });
 ```
 

--- a/www/commands/fetch.md
+++ b/www/commands/fetch.md
@@ -21,6 +21,14 @@ response text.
 
 This command saves the result into the `it` variable.
 
+This command triggers the event `hyperscript:beforeFetch`. This event receives the parameters for the command as its `event.detail`. This is useful to globally change the behaviour of fetch, for example to add a custom header to every request, for example adding an `X-CSRFToken` Header for django apps:
+
+```javascript
+document.body.addEventListener('hyperscript:beforeFetch', (event) => {
+    event.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';
+});
+```
+
 This command is asynchronous.
 
 ### Examples


### PR DESCRIPTION
This enables the user to globally access and modify the parameters of fetch. The command parameters are passed to the `event.detail` object which can be modified in the handler. The modified values are passed to the [fetch-API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch).

This is especially useful for backends which require certain custom headers i.e. django's X-CSRFToken. Instead of setting this on every fetch command, the user can now use the event handler to do this.