### PR TITLE
Complete URLs in socket feature

### DIFF
--- a/src/lib/plugin/socket.js
+++ b/src/lib/plugin/socket.js
@@ -9,8 +9,22 @@ function genUUID() {
 	});
 }
 
+function parseUrl(url) {
+	var finalUrl = url;
+	if (finalUrl.indexOf("/") === 0) {  // complete absolute paths without scheme only
+		var basePart = window.location.hostname + (window.location.port ? ':' + window.location.port : '');
+		if (window.location.protocol === 'https:') {
+			finalUrl = "wss://" + basePart + finalUrl;
+		} else if (window.location.protocol === 'http:') {
+			finalUrl = "ws://" + basePart + finalUrl;
+		}
+	}
+	return finalUrl;
+}
+
 function createSocket(url) {
-	return new WebSocket(url.evaluate());
+	var parsedUrl = parseUrl(url.evaluate());
+	return new WebSocket(parsedUrl);
 }
 
 /**

--- a/test/features/socket.js
+++ b/test/features/socket.js
@@ -1,0 +1,50 @@
+describe("the socket feature", function () {
+	it("can handle different url schemes", function () {
+		try {
+			_hyperscript("socket MySocket ws:/ws/test/ on message as json log message end");
+		} catch (e) {
+			if (e instanceof DOMException) {
+				assert.fail("Scheme ws: Should not have thrown");
+			}
+		}
+		assert.property(window, "MySocket");
+		delete window.MySocket;
+
+		try {
+			_hyperscript("socket MySocket wss:/ws/test/ on message as json log message end");
+		} catch (e) {
+			if (e instanceof DOMException) {
+				assert.fail("Scheme wss: Should not have thrown");
+			}
+		}
+		assert.property(window, "MySocket");
+		delete window.MySocket;
+
+		try {
+			_hyperscript("socket MySocket /ws/test/ on message as json log message end");
+		} catch (e) {
+			if (e instanceof DOMException) {
+				assert.fail("No scheme: Should not have thrown");
+			}
+		}
+		assert.property(window, "MySocket");
+		var url = window.MySocket["raw"].url
+		if (window.location.protocol === "http:")
+			assert.include(url, "ws");
+		else
+			assert.include(url, "wss");
+		assert.include(url, window.location.hostname);
+		if (window.location.port)
+			assert.include(url, window.location.port);
+		delete window.MySocket;
+
+		try {
+			_hyperscript("socket MySocket abc:/ws/test/ on message as json log message end");
+		} catch (e) {
+			if (!(e instanceof DOMException)) {
+				assert.fail("Scheme abc: Should have thrown");
+			}
+		}
+		assert.notProperty(window, "MySocket");
+	});
+});

--- a/test/index.html
+++ b/test/index.html
@@ -62,6 +62,7 @@
 		<script src="features/js.js"></script>
 		<script src="features/init.js"></script>
 		<script src="features/set.js"></script>
+		<script src="features/socket.js"></script>
 
 		<!-- commands -->
 		<script src="commands/add.js"></script>

--- a/test/sockets/scratch.html
+++ b/test/sockets/scratch.html
@@ -8,7 +8,7 @@
 	<body style="padding: 20px; font-family: sans-serif">
 		<script src="../../src/lib/core.js"></script>
 		<script src="../../src/lib/web.js"></script>
-		<script src="../../src/lib/socket.js"></script>
+		<script src="../../src/lib/plugin/socket.js"></script>
 
 		<em>Web Socket Playground</em>
 		<hr />

--- a/www/features/socket.md
+++ b/www/features/socket.md
@@ -15,7 +15,7 @@ Note: if you want the socket feature, you must either use the "Whole 9 Yards" re
 <br/>
 
 - `socket-name` is a name for the socket. This is available in the current hypertext scope and exposes additional data about the browser [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) object.
-- `socket-url` is the address that the socket is connected to.
+- `socket-url` is the address that the socket is connected to. Schemes like ws or wss can optionally be specified (like in `socket MySocket ws://myserver.com/example`). If not specified, hyperscript defaults to add the location's scheme-type, host and port (like in `socket MySocket /example`).
 - `with timeout <time expr>` allows you to set a default timeout for [RPC calls](#rpc).
 - `on message` is an optional message handler body that can be run when messages are received. The `message` symbol
   will be set to the message value. The optional `as json` modifier will convert the message to json before running


### PR DESCRIPTION
Hyperscript should complete WebSocket URLs in the socket feature the same way htmx does (see PR [#382](https://github.com/bigskysoftware/htmx/pull/382) by @srkunze):

- If no host and port is provided, use the current one
- For http use ws, for https use wss

(See https://github.com/bigskysoftware/_hyperscript/issues/221)