### PR TITLE
process text/hyperscript <script> tags sequentially

### DIFF
--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -5341,24 +5341,27 @@ if ("document" in globalScope) {
 	/** @type {HTMLScriptElement[]} */
 	var scripts = Array.from(document.querySelectorAll("script[type='text/hyperscript'][src]"))
 	Promise.all(
-		scripts.map(function (script) {
-			return fetch(script.src)
-				.then(function (res) {
-					return res.text();
-				})
-				.then(function (code) {
-					return _runtime.evaluate(code);
-				});
+			scripts.map(function (script) {
+				return fetch(script.src)
+					.then(function (res) {
+						return res.text();
+					});
+			})
+		)
+		.then(function (script_values) {
+			// forEach instead of map, since the return value of .evaluate is not used by the then
+			return script_values.forEach(_runtime.evaluate);
 		})
-	).then(function () {
-		ready(function () {
-			mergeMetaConfig();
-			_runtime.processNode(document.documentElement);
-			document.addEventListener("htmx:load", function (/** @type {CustomEvent} */ evt) {
-				_runtime.processNode(evt.detail.elt);
+		.then(function () {
+			ready(function () {
+				mergeMetaConfig();
+				_runtime.processNode(document.documentElement);
+				document.addEventListener("htmx:load", function (/** @type {CustomEvent} */ evt) {
+
+					_runtime.processNode(evt.detail.elt);
+				});
 			});
 		});
-	});
 }
 
 //====================================================================

--- a/www/_includes/layout.njk
+++ b/www/_includes/layout.njk
@@ -13,7 +13,7 @@ title: ///_hyperscript
     <script src="https://unpkg.com/prismjs@1.25.0/components/prism-markup.min.js"></script>
     <script src="https://unpkg.com/prismjs@1.25.0/components/prism-clike.min.js"></script>
     <script src="https://unpkg.com/prismjs@1.25.0/components/prism-javascript.min.js"></script>
-    <script src="https://unpkg.com/prism-hyperscript@1.0.5/"></script>
+    <script src="https://unpkg.com/prism-hyperscript@1.0.5/prism-hyperscript.js"></script>
     <script src="/js/_hyperscript_w9y.min.js"></script>
 </head>
 <body>

--- a/www/_includes/layout.njk
+++ b/www/_includes/layout.njk
@@ -13,7 +13,7 @@ title: ///_hyperscript
     <script src="https://unpkg.com/prismjs@1.25.0/components/prism-markup.min.js"></script>
     <script src="https://unpkg.com/prismjs@1.25.0/components/prism-clike.min.js"></script>
     <script src="https://unpkg.com/prismjs@1.25.0/components/prism-javascript.min.js"></script>
-    <script src="/js/prism-hyperscript.js"></script>
+    <script src="https://unpkg.com/prism-hyperscript@1.0.5/"></script>
     <script src="/js/_hyperscript_w9y.min.js"></script>
 </head>
 <body>


### PR DESCRIPTION
When including external _hs files like so:
```html
<script type="text/hyperscript" src="one._hs"></script> <!-- one._hs defines methods, could be a large file -->
<script type="text/hyperscript" src="two._hs"></script> <!-- two._hs depends on methods in one._hs -->
<script src="dist/_hyperscript_w9y.min.js"></script>
```
the current behaviour of including these scripts is to fetch the scripts in a promise and execute (`_runtime.evaluate`) the code as it comes in from fetch. However, when one file is bigger or due to random network effects, this order of execution is currently random. When your second _hs file depends on methods or something from the first _hs file, this can sometimes lead to errors.
In this pull request propose changing this exeuction behavior to follow the order in which the scripts are included in the page, just like JS files would be executed.
In order to do this, I have moved the script execution to after the Promise.all. Since the `scripts` variable is ordered[^1] and map keeps this order, the `script_values` are ordered as well, and thus the execution is done correctly.   

Before this change:
![image](https://user-images.githubusercontent.com/2529002/147262743-91023b70-46e9-4e55-b99c-1660caf59b13.png)

After this change:
![image](https://user-images.githubusercontent.com/2529002/147262835-d40803eb-58d3-4a44-a0c6-12b0bf9357a9.png)


[^1]: https://stackoverflow.com/questions/8203770/using-queryselectorall-is-the-result-returned-by-the-method-ordered