### PR TITLE
on: typo with queue

### DIFF
--- a/www/features/on.md
+++ b/www/features/on.md
@@ -115,7 +115,7 @@ If you postfix the event with `queue` you may pick from one of four strategies:
 - `first` - The first event that arrives will be queued, all others will be dropped
 - `last` - The last event that arrives will be queued, all others will be dropped
 
-`queued last` is the default behavior
+`queue last` is the default behavior
 
 ### <a name="exceptions"></a>[Exceptions](#exceptions)
 


### PR DESCRIPTION
though `queued last` is a bit more natural. Perhaps