### PR TITLE
fix rare WeakMap error if 'elt' is null

### DIFF
--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -1702,7 +1702,10 @@ var _runtime = (function () {
 	function getHyperscriptFeatures(elt) {
 		var hyperscriptFeatures = hyperscriptFeaturesMap.get(elt);
 		if (typeof hyperscriptFeatures === 'undefined') {
-			hyperscriptFeaturesMap.set(elt, hyperscriptFeatures = {});
+			if (elt) {
+				// in some rare cases, elt is null and this line crashes
+				hyperscriptFeaturesMap.set(elt, hyperscriptFeatures = {});
+			}
 		}
 		return hyperscriptFeatures;
 	}


### PR DESCRIPTION
Every so often, hyperscript crashes with the error
```
_hyperscript_w9y-0.9.4.min.js?v=c6fdfd9889:1 
        
       Uncaught (in promise) TypeError: Invalid value used as weak map key
    at WeakMap.set (<anonymous>)
    at w (_hyperscript_w9y-0.9.4.min.js?v=c6fdfd9889:1:15847)
    at evaluate (_hyperscript_w9y-0.9.4.min.js?v=c6fdfd9889:1:18308)
    at Array.forEach (<anonymous>)
    at _hyperscript_w9y-0.9.4.min.js?v=c6fdfd9889:1:69188

// since this is minified, the lines are kind of messed up, however:
// - WeakMap.set happens in getHyperscriptFeatures on line 1699 of core.js
// - getHyperscriptFeatures  is called in line 1857 of evaluate (core.js)
// - evaluate is called as _runtime.evaluate in line 5690 after downloading external ._hs scripts (core.js)
// - elt should in this case be <body> but is (very rarely) null (in core.js evaluate line 1847):
/*
		var body = 'document' in globalScope
			? globalScope.document.body
			: new HyperscriptModule(args && args.module);
*/
```

This happens when 'elt' is null for some reason.
This patch adds a check to skip setting this null key on the hyperscriptFeaturesMap WeakMap to avoid this error (which breaks the rest of the scripts of the page).
I am not sure if this is the right way to fix this patch (and something else might break because now hyperscriptFeaturesMap is missing something?), perhaps the fix needs to be done somewhere else (and elt may never be null?).
This seems to fix the issue for me though, so hopefully it can benefit others as well.

This happens on the latest release (0.9.4) and also earlier.