### PR TITLE
fix(docs): Incorrect target on vanilla-remove-me example

### DIFF
--- a/www/comparison.md
+++ b/www/comparison.md
@@ -35,7 +35,7 @@ Pattern: fade and remove an element after it is clicked
 .fade-out {
   opacity: 0;
 }
-#remove-me {
+#vanilla-remove-me {
   transition: opacity 1s ease-in-out;
 }
 </style>
@@ -65,7 +65,7 @@ Pattern: fade and remove an element after it is clicked
 .fade-out {
   opacity: 0;
 }
-#remove-me {
+#vanilla-remove-me {
   transition: opacity 1s ease-in-out;
 }
 </style>


### PR DESCRIPTION
Perhaps illustrating the problem firsthand 😄 , the ID of the div and that of the CSS don't match. So, no transition is occurring, and the event `transitionend` never fires. The element snaps its opacity onclick, but is never removed.

Change should make the example functional again.