### PR TITLE
Improve documentation about checking undefined and empty strings/arrays

### DIFF
--- a/www/docs.md
+++ b/www/docs.md
@@ -568,7 +568,7 @@ A small sampling is shown below:
 `[[a]] is not [[b]]`
 	Same as {%syntax "[[a]] != [[b]]"%}.
 `no [[a]]`
-	Same as {%syntax "[[a]] == null or [[a]] == undefined"%}.
+	Same as {%syntax "[[a]] == null or [[a]] == undefined or [[a.length]] == 0"%}.
 `[[element]] matches [[selector]]`
 	Does a CSS test, i.e. `if I match .selected`.
 `[[a]] exists`

--- a/www/expressions/no.md
+++ b/www/expressions/no.md
@@ -9,15 +9,15 @@
 
 ### Description
 
-The `no` operator returns true if the value of the expression is `null` or an
-object of length 0 (an empty string or array). You can also accomplish this
+The `no` operator returns true if the value of the expression is `null`, `undefined` or
+an object of length 0 (an empty string or array). You can also accomplish this
 same task using the [`is empty` and `is not empty` comparisons operators](/expressions/comparison-operator).
 
 ### Examples
 
 ```html
 <div
-  _="on click 
+  _="on click
           if no .tabs log 'No tabs found!'"
 >
   Check for Tabs


### PR DESCRIPTION
Small additions to the current documentation clarifying the behavior of the `no` operator.