### PR TITLE
Add failing test for variables inside behaviors

### DIFF
--- a/test/features/behavior.js
+++ b/test/features/behavior.js
@@ -73,4 +73,28 @@ describe("the behavior feature", function () {
 		}, 10);
 	});
 
+	it("can declare variables in init blocks", function (done) {
+		var behavior = make(
+			`<script type=text/hyperscript>
+				behavior Behave
+					init
+						set element's foo to 1
+						set element's bar to {}
+					end
+					on click
+						increment element's foo
+						set element's bar["count"] to element's foo
+						put element's bar["count"] into me
+					end
+				end
+			`);
+		var div = make("<div _='install Behave'></div>");
+		div.textContent.should.equal("");
+		div.click();
+		div.textContent.should.equal("2");
+		div.click();
+		div.textContent.should.equal("3");
+		delete window.Behave;
+	});
+
 });

--- a/test/features/behavior.js
+++ b/test/features/behavior.js
@@ -87,6 +87,7 @@ describe("the behavior feature", function () {
 						put element's bar["count"] into me
 					end
 				end
+			</script>
 			`);
 		var div = make("<div _='install Behave'></div>");
 		div.textContent.should.equal("");


### PR DESCRIPTION
The browser console, when running this failing test says `'element's bar' is null` along with the hypertrace.

Suprisingly, the following (which is almost the same) runs correctly on the playground:

```
<script type="text/hyperscript">
behavior Behave
  init
    set element's foo to 0
    set element's bar to {}
  end

  on click
    increment element's foo
    set element's bar["count"] to element's foo
    put element's bar["count"] at the end of #output
  end

end
</script>

<button id="elem" _="install Behave init put 'foo' at the end of  #output">CLICK ME</button>
<hr/>
<div id="output"></div>
```

(as of today, the current release seems to be 0.9.5, which I've confirmed to have the issue)