### PR TITLE
typo on put-after syntax

### DIFF
--- a/www/docs.md
+++ b/www/docs.md
@@ -1367,7 +1367,7 @@ The `put` command can be used in the following ways:
 `put [[content]] at the end of [[element]]`
 	Puts the content at the end of the element, using [`Element.append`][].
 `put [[content]] after [[element]]`
-	Puts the content in front of the element, using [`Element.after`][].
+	Puts the content after the element, using [`Element.after`][].
 {% endsyntaxes %}
 
 [`Element.before`]:  https://developer.mozilla.org/en-US/docs/Web/API/Element/before


### PR DESCRIPTION
A little  typo on:

> **put content after element**
> Puts the content in front of the element, using Element.after

Changed to:

> **put content after element**
> Puts the content after the element, using Element.after