### PR TITLE
Isolate local variables into `context.locals`

### DIFF
--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -1721,6 +1721,34 @@ var _runtime = (function () {
 		}
 	}
 
+	class Context {
+		/**
+		* @param {*} owner
+		* @param {*} feature
+		* @param {*} hyperscriptTarget
+		* @param {*} event
+		*/
+		constructor(owner, feature, hyperscriptTarget, event) {
+			this.meta = {
+				parser: _parser,
+				lexer: _lexer,
+				runtime: _runtime,
+				owner: owner,
+				feature: feature,
+				iterators: {},
+				ctx: this
+			}
+			this.locals = {};
+			this.me = hyperscriptTarget,
+			this.event = event;
+			this.target = event ? event.target : null;
+			this.detail = event ? event.detail : null;
+			this.sender = event ? event.detail ? event.detail.sender : null : null;
+			this.body = "document" in globalScope ? document.body : null;
+			addFeatures(owner, this);
+		}
+	}
+
 	/**
 	* @param {*} owner
 	* @param {*} feature
@@ -1729,28 +1757,7 @@ var _runtime = (function () {
 	* @returns {Context}
 	*/
 	function makeContext(owner, feature, hyperscriptTarget, event) {
-		/** @type {Context} */
-		var ctx = {
-			meta: {
-				parser: _parser,
-				lexer: _lexer,
-				runtime: _runtime,
-				owner: owner,
-				feature: feature,
-				iterators: {},
-				__ht_context: true
-			},
-			locals: {},
-			me: hyperscriptTarget,
-			event: event,
-			target: event ? event.target : null,
-			detail: event ? event.detail : null,
-			sender: event ? event.detail ? event.detail.sender : null : null,
-			body: "document" in globalScope ? document.body : null,
-		};
-		ctx.meta.ctx = ctx;
-		addFeatures(owner, ctx);
-		return ctx;
+		return new Context(owner, feature, hyperscriptTarget, event)
 	}
 
 	/**
@@ -1983,7 +1990,7 @@ var _runtime = (function () {
 	* @returns {boolean}
 	*/
 	function isHyperscriptContext(context) {
-		return context.meta && context.meta.__ht_context
+		return context instanceof Context;
 	}
 
 	/**

--- a/src/lib/core.js
+++ b/src/lib/core.js
@@ -1975,13 +1975,13 @@ var _runtime = (function () {
 	*/
 	function resolveSymbol(str, context, type) {
 		if (str === "me" || str === "my" || str === "I") {
-			return context["me"];
+			return context.me;
 		}
 		if (str === "it" || str === "its") {
-			return context["result"];
+			return context.result;
 		}
 		if (str === "you" || str === "your" || str === "yourself") {
-			return context["beingTold"];
+			return context.beingTold;
 		} else {
 			if (type === "global") {
 				return globalScope[str];

--- a/src/lib/plugin/template.js
+++ b/src/lib/plugin/template.js
@@ -2,7 +2,7 @@
 function compileTemplate(template) {
 	return template.replace(/(?:^|\n)([^@]*)@?/gm, function (match, p1) {
 		var templateStr = (" " + p1).replace(/([^\\])\$\{/g, "$1$${escape html ").substring(1);
-		return "\ncall __ht_template_result.push(`" + templateStr + "`)\n";
+		return "\ncall meta.__ht_template_result.push(`" + templateStr + "`)\n";
 	});
 }
 
@@ -13,7 +13,9 @@ export default _hyperscript => {
 
 	function renderTemplate(template, ctx) {
 		var buf = [];
-		_hyperscript.evaluate(template, Object.assign({ __ht_template_result: buf }, ctx));
+		const renderCtx = Object.assign({}, ctx);
+		renderCtx.meta = Object.assign({ __ht_template_result: buf }, ctx.meta);
+		_hyperscript.evaluate(template, renderCtx);
 		return buf.join("");
 	}
 
@@ -28,7 +30,9 @@ export default _hyperscript => {
 			args: [template_, templateArgs],
 			op: function (ctx, template, templateArgs) {
 				if (!(template instanceof Element)) throw new Error(template_.sourceFor() + " is not an element");
-				ctx.result = renderTemplate(compileTemplate(template.innerHTML), templateArgs);
+				const context = _hyperscript.internals.runtime.makeContext()
+				context.locals = templateArgs;
+				ctx.result = renderTemplate(compileTemplate(template.innerHTML), context);
 				return runtime.findNext(this, ctx);
 			},
 		};

--- a/src/lib/web.js
+++ b/src/lib/web.js
@@ -984,7 +984,7 @@ export default _hyperscript => {
 				};
 
 				runtime.forEach(propsToMeasure, function (prop) {
-					if (prop in ctx.result) ctx[prop] = ctx.result[prop];
+					if (prop in ctx.result) ctx.locals[prop] = ctx.result[prop];
 					else throw "No such measurement as " + prop;
 				});
 

--- a/src/lib/web.js
+++ b/src/lib/web.js
@@ -108,14 +108,14 @@ export default _hyperscript => {
 						runtime.forEach(classRefs, function (classRef) {
 							runtime.implicitLoop(to, function (target) {
 								if (when) {
-									context['result'] = target;
+									context.result = target;
 									let whenResult = runtime.evaluateNoPromise(when, context);
 									if (whenResult) {
 										if (target instanceof Element) target.classList.add(classRef.className);
 									} else {
 										if (target instanceof Element) target.classList.remove(classRef.className);
 									}
-									context['result'] = null;
+									context.result = null;
 								} else {
 									if (target instanceof Element) target.classList.add(classRef.className);
 								}
@@ -134,14 +134,14 @@ export default _hyperscript => {
 						runtime.nullCheck(to, toExpr);
 						runtime.implicitLoop(to, function (target) {
 							if (when) {
-								context['result'] = target;
+								context.result = target;
 								let whenResult = runtime.evaluateNoPromise(when, context);
 								if (whenResult) {
 									target.setAttribute(attributeRef.name, attributeRef.value);
 								} else {
 									target.removeAttribute(attributeRef.name);
 								}
-								context['result'] = null;
+								context.result = null;
 							} else {
 								target.setAttribute(attributeRef.name, attributeRef.value);
 							}
@@ -566,14 +566,14 @@ export default _hyperscript => {
 					runtime.nullCheck(target, targetExpr);
 					runtime.implicitLoop(target, function (elt) {
 						if (when) {
-							ctx['result'] = elt;
+							ctx.result = elt;
 							let whenResult = runtime.evaluateNoPromise(when, ctx);
 							if (whenResult) {
 								hideShowStrategy("show", elt, arg);
 							} else {
 								hideShowStrategy("hide", elt);
 							}
-							ctx['result'] = null;
+							ctx.result = null;
 						} else {
 							hideShowStrategy("show", elt, arg);
 						}

--- a/test/core/scoping.js
+++ b/test/core/scoping.js
@@ -14,6 +14,17 @@ describe("scoping", function () {
 		div.getAttribute("out").should.equal("10");
 	});
 
+
+	it("locally scoped variables don't clash with built-in variables", function () {
+		var div = make(
+			"<div id='d1' _='on click repeat for meta in [1, 2, 3] set @out to meta end'></div>"
+		);
+		div.click();
+		// meta should still be the object inside context, not a number
+		// TODO: Should trying to set 'meta', 'result', etc. throw an exception?
+		div.getAttribute("out").should.equal("[object Object]");
+	});
+
 	it("locally scoped variables do not span features", function () {
 		var div = make(
 			"<div id='d1' _='on click 1 set x to 10 " +

--- a/test/expressions/asExpression.js
+++ b/test/expressions/asExpression.js
@@ -69,7 +69,7 @@ describe("as operator", function () {
 	});
 
 	it("converts value as Object", function () {
-		var result = evalHyperScript("x as Object", { x: { foo: "bar" } });
+		var result = evalHyperScript("x as Object", { locals: { x: { foo: "bar" } } });
 		result["foo"].should.equal("bar");
 	});
 
@@ -78,7 +78,7 @@ describe("as operator", function () {
 		node.name = "test-name";
 		node.value = "test-value";
 
-		var result = evalHyperScript("x as Values", { x: node });
+		var result = evalHyperScript("x as Values", { locals: { x: node } });
 		result["test-name"].should.equal("test-value");
 	});
 
@@ -92,7 +92,7 @@ describe("as operator", function () {
                 <input name="phone" value="555-1212">
             </div>`;
 
-		var result = evalHyperScript("x as Values", { x: node });
+		var result = evalHyperScript("x as Values", { locals: { x: node } });
 		result.firstName.should.equal("John");
 		result.lastName.should.equal("Connor");
 		result.areaCode.should.equal("213");
@@ -126,7 +126,7 @@ describe("as operator", function () {
                 <input type="radio" name="gender" value="Other">
             </div>`;
 
-		var result = evalHyperScript("x as Values", { x: node });
+		var result = evalHyperScript("x as Values", { locals: { x: node } });
 		result.gender.should.equal("Male");
 	});
 
@@ -139,7 +139,7 @@ describe("as operator", function () {
                 <input type="checkbox" name="gender" value="Other" checked>
             </div>`;
 
-		var result = evalHyperScript("x as Values", { x: node });
+		var result = evalHyperScript("x as Values", { locals: { x: node } });
 		result.gender[0].should.equal("Male");
 		result.gender[1].should.equal("Female");
 		result.gender[2].should.equal("Other");
@@ -155,7 +155,7 @@ describe("as operator", function () {
                 <option value="possum">Sleepy Boi</option>
             </div>`;
 
-		var result = evalHyperScript("x as Values", { x: node });
+		var result = evalHyperScript("x as Values", { locals: { x: node } });
 		result.animal[0].should.equal("dog");
 		result.animal[1].should.equal("raccoon");
 	});
@@ -199,7 +199,7 @@ describe("as operator", function () {
         <input type="checkbox" name="gender" value="Other" checked>
         `;
 
-		var result = evalHyperScript("x as Values", { x: node });
+		var result = evalHyperScript("x as Values", { locals: { x: node } });
 		result.firstName.should.equal("John");
 		result.lastName.should.equal("Connor");
 		result.phone.should.equal("555-1212");
@@ -218,7 +218,7 @@ describe("as operator", function () {
 		d1.id = "myDiv";
 		d1.innerText = "With Text";
 
-		var result = evalHyperScript("d as HTML", { d: d1 });
+		var result = evalHyperScript("d as HTML", { locals: { d: d1 } });
 		result.should.equal(`<div id="myDiv">With Text</div>`);
 	});
 
@@ -245,7 +245,7 @@ describe("as operator", function () {
 		}
 
 		var result = evalHyperScript("nodeList as HTML", {
-			nodeList: fragment.childNodes,
+			locals: { nodeList: fragment.childNodes, }
 		});
 		result.should.equal(`<div id="first">With Text</div><span id="second"></span><i id="third"></i>`);
 	});
@@ -253,21 +253,21 @@ describe("as operator", function () {
 	it("converts an array into HTML", function () {
 		var d1 = ["this-", "is-", "html"];
 
-		var result = evalHyperScript("d as HTML", { d: d1 });
+		var result = evalHyperScript("d as HTML", { locals: { d: d1 } });
 		result.should.equal(`this-is-html`);
 	});
 
 	it("converts numbers things 'HTML'", function () {
 		var value = 123;
 
-		var result = evalHyperScript("value as HTML", { value: value });
+		var result = evalHyperScript("value as HTML", { locals: { value: value } });
 		result.should.equal("123");
 	});
 
 	it("converts strings into fragments", function () {
 		var value = "<p></p>";
 
-		var result = evalHyperScript("value as Fragment", { value: value });
+		var result = evalHyperScript("value as Fragment", { locals: { value: value } });
 		result.childElementCount.should.equal(1);
 		result.firstChild.tagName.should.equal("P");
 	});
@@ -275,7 +275,7 @@ describe("as operator", function () {
 	it("converts elements into fragments", function () {
 		var value = document.createElement("p");
 
-		var result = evalHyperScript("value as Fragment", { value: value });
+		var result = evalHyperScript("value as Fragment", { locals: { value: value } });
 		result.childElementCount.should.equal(1);
 		result.firstChild.tagName.should.equal("P");
 	});
@@ -283,7 +283,7 @@ describe("as operator", function () {
 	it("converts arrays into fragments", function () {
 		var value = [document.createElement("p"), "<p></p>"];
 
-		var result = evalHyperScript("value as Fragment", { value: value });
+		var result = evalHyperScript("value as Fragment", { locals: { value: value } });
 		result.childElementCount.should.equal(2);
 		result.firstChild.tagName.should.equal("P");
 		result.lastChild.tagName.should.equal("P");
@@ -321,7 +321,7 @@ describe("as operator", function () {
                 <input name="phone" value="555-1212">
             </div>`;
 
-		var result = evalHyperScript("x as Values:JSON", { x: node });
+		var result = evalHyperScript("x as Values:JSON", { locals: { x: node } });
 		result.should.equal('{"firstName":"John","lastName":"Connor","areaCode":"213","phone":"555-1212"}');
 	});
 
@@ -335,7 +335,7 @@ describe("as operator", function () {
                 <input name="phone" value="555-1212">
             </div>`;
 
-		var result = evalHyperScript("x as Values:Form", { x: node });
+		var result = evalHyperScript("x as Values:Form", { locals: { x: node } });
 		result.should.equal('firstName=John&lastName=Connor&areaCode=213&phone=555-1212');
 	});
 

--- a/test/expressions/attributeRef.js
+++ b/test/expressions/attributeRef.js
@@ -26,7 +26,7 @@ describe("the attributeRef expression", function () {
 
 	it("attributeRef can be set as prop", function () {
 		var div = make("<div data-foo='red'></div>");
-		var value = _hyperscript("set x[@data-foo] to 'blue'", { x: div });
+		var value = _hyperscript("set x[@data-foo] to 'blue'", { locals: { x: div } });
 		div.getAttribute("data-foo").should.equal("blue");
 	});
 
@@ -38,13 +38,13 @@ describe("the attributeRef expression", function () {
 
 	it("attributeRef can be set indirectly", function () {
 		var div = make("<div data-foo='red'></div>");
-		var value = _hyperscript("set [@data-foo] of x to 'blue'", { x: div });
+		var value = _hyperscript("set [@data-foo] of x to 'blue'", { locals: { x: div } });
 		div.getAttribute("data-foo").should.equal("blue");
 	});
 
 	it("attributeRef can be put indirectly", function () {
 		var div = make("<div data-foo='red'></div>");
-		var value = _hyperscript("put 'blue' into x[@data-foo]", { x: div });
+		var value = _hyperscript("put 'blue' into x[@data-foo]", { locals: { x: div } });
 		div.getAttribute("data-foo").should.equal("blue");
 	});
 
@@ -74,7 +74,7 @@ describe("the attributeRef expression", function () {
 
 	it("attributeRef can be set as prop w/ short syntax", function () {
 		var div = make("<div data-foo='red'></div>");
-		var value = _hyperscript("set x@data-foo to 'blue'", { x: div });
+		var value = _hyperscript("set x@data-foo to 'blue'", { locals: { x: div } });
 		div.getAttribute("data-foo").should.equal("blue");
 	});
 
@@ -86,13 +86,13 @@ describe("the attributeRef expression", function () {
 
 	it("attributeRef can be set indirectly w/ short syntax", function () {
 		var div = make("<div data-foo='red'></div>");
-		var value = _hyperscript("set @data-foo of x to 'blue'", { x: div });
+		var value = _hyperscript("set @data-foo of x to 'blue'", { locals: { x: div } });
 		div.getAttribute("data-foo").should.equal("blue");
 	});
 
 	it("attributeRef can be put indirectly w/ short syntax", function () {
 		var div = make("<div data-foo='red'></div>");
-		var value = _hyperscript("put 'blue' into x@data-foo", { x: div });
+		var value = _hyperscript("put 'blue' into x@data-foo", { locals: { x: div } });
 		div.getAttribute("data-foo").should.equal("blue");
 	});
 

--- a/test/expressions/comparisonOperator.js
+++ b/test/expressions/comparisonOperator.js
@@ -178,7 +178,7 @@ describe("the comparisonOperator expression", function () {
 		result.should.equal(true);
 
 		var div = make("<div class='foo'></div>");
-		var result = evalHyperScript("x matches .foo", { x: div });
+		var result = evalHyperScript("x matches .foo", { locals: { x: div } });
 		result.should.equal(true);
 
 		var div = make("<div class='foo'></div>");
@@ -186,7 +186,7 @@ describe("the comparisonOperator expression", function () {
 		result.should.equal(false);
 
 		var div = make("<div class='foo'></div>");
-		var result = evalHyperScript("x matches .bar", { x: div });
+		var result = evalHyperScript("x matches .bar", { locals: { x: div } });
 		result.should.equal(false);
 	});
 
@@ -196,7 +196,7 @@ describe("the comparisonOperator expression", function () {
 		result.should.equal(false);
 
 		var div = make("<div class='foo'></div>");
-		var result = evalHyperScript("x does not match .foo", { x: div });
+		var result = evalHyperScript("x does not match .foo", { locals: { x: div } });
 		result.should.equal(false);
 
 		var div = make("<div class='foo'></div>");
@@ -204,7 +204,7 @@ describe("the comparisonOperator expression", function () {
 		result.should.equal(true);
 
 		var div = make("<div class='foo'></div>");
-		var result = evalHyperScript("x does not match .bar", { x: div });
+		var result = evalHyperScript("x does not match .bar", { locals: { x: div } });
 		result.should.equal(true);
 	});
 
@@ -230,25 +230,25 @@ describe("the comparisonOperator expression", function () {
 
 		var result = evalHyperScript("I contain that", {
 			me: outer,
-			that: inner,
+			locals: { that: inner, }
 		});
 		result.should.equal(true);
 
 		var result = evalHyperScript("I contain that", {
 			me: inner,
-			that: outer,
+			locals: { that: outer, }
 		});
 		result.should.equal(false);
 
 		var result = evalHyperScript("that contains me", {
 			me: outer,
-			that: inner,
+			locals: { that: inner, }
 		});
 		result.should.equal(false);
 
 		var result = evalHyperScript("that contains me", {
 			me: inner,
-			that: outer,
+			locals: { that: outer, }
 		});
 		result.should.equal(true);
 	});
@@ -259,13 +259,13 @@ describe("the comparisonOperator expression", function () {
 
 		var result = evalHyperScript("I contain that", {
 			me: outer,
-			that: inner,
+			locals: { that: inner, }
 		});
 		result.should.equal(true);
 
 		var result = evalHyperScript("that contains me", {
 			me: inner,
-			that: outer,
+			locals: { that: outer, }
 		});
 		result.should.equal(true);
 	});
@@ -286,26 +286,34 @@ describe("the comparisonOperator expression", function () {
 		var inner = byId("d2");
 
 		var result = evalHyperScript("foo includes foobar", {
-			foo: "foo",
-			foobar: "foobar",
+			locals: {
+				foo: "foo",
+				foobar: "foobar",
+			}
 		});
 		result.should.equal(false);
 
 		var result = evalHyperScript("foobar includes foo", {
-			foo: "foo",
-			foobar: "foobar",
+			locals: {
+				foo: "foo",
+				foobar: "foobar",
+			}
 		});
 		result.should.equal(true);
 
 		var result = evalHyperScript("foo does not include foobar", {
-			foo: "foo",
-			foobar: "foobar",
+			locals: {
+				foo: "foo",
+				foobar: "foobar",
+			}
 		});
 		result.should.equal(true);
 
 		var result = evalHyperScript("foobar does not include foo", {
-			foo: "foo",
-			foobar: "foobar",
+			locals: {
+				foo: "foo",
+				foobar: "foobar",
+			}
 		});
 		result.should.equal(false);
 
@@ -317,13 +325,13 @@ describe("the comparisonOperator expression", function () {
 
 		var result = evalHyperScript("I include that", {
 			me: outer,
-			that: inner,
+			locals: { that: inner, }
 		});
 		result.should.equal(true);
 
 		var result = evalHyperScript("that includes me", {
 			me: inner,
-			that: outer,
+			locals: { that: outer, }
 		});
 		result.should.equal(true);
 	});
@@ -345,25 +353,25 @@ describe("the comparisonOperator expression", function () {
 
 		var result = evalHyperScript("I do not contain that", {
 			me: outer,
-			that: inner,
+			locals: { that: inner, }
 		});
 		result.should.equal(false);
 
 		var result = evalHyperScript("I do not contain that", {
 			me: inner,
-			that: outer,
+			locals: { that: outer, }
 		});
 		result.should.equal(true);
 
 		var result = evalHyperScript("that does not contains me", {
 			me: outer,
-			that: inner,
+			locals: { that: inner, }
 		});
 		result.should.equal(true);
 
 		var result = evalHyperScript("that does not contains me", {
 			me: inner,
-			that: outer,
+			locals: { that: outer, }
 		});
 		result.should.equal(false);
 	});

--- a/test/expressions/positionalExpression.js
+++ b/test/expressions/positionalExpression.js
@@ -42,7 +42,7 @@ describe("the positional expression", function () {
 				"                  <div id='d2' class='c1'></div>" +
 				"                  <div id='d3' class='c1'></div></div>"
 		);
-		var result = evalHyperScript("the first of div", { div: div });
+		var result = evalHyperScript("the first of div", { locals: { div: div } });
 		result.should.equal(byId("d1"));
 	});
 
@@ -52,7 +52,7 @@ describe("the positional expression", function () {
 				"                  <div id='d2' class='c1'></div>" +
 				"                  <div id='d3' class='c1'></div></div>"
 		);
-		var result = evalHyperScript("the last of div", { div: div });
+		var result = evalHyperScript("the last of div", { locals: { div: div } });
 		result.should.equal(byId("d3"));
 	});
 

--- a/test/expressions/possessiveExpression.js
+++ b/test/expressions/possessiveExpression.js
@@ -7,7 +7,7 @@ describe("possessiveExpression", function () {
 	});
 
 	it("can access basic properties", function () {
-		var result = evalHyperScript("foo's foo", { foo: { foo: "foo" } });
+		var result = evalHyperScript("foo's foo", { locals: { foo: { foo: "foo" } } });
 		result.should.equal("foo");
 	});
 
@@ -74,7 +74,7 @@ describe("possessiveExpression", function () {
 
 	it("can access basic attribute", function () {
 		var div = make("<div data-foo='bar'></div>");
-		var result = evalHyperScript("foo's [@data-foo]", { foo: div });
+		var result = evalHyperScript("foo's [@data-foo]", { locals: { foo: div } });
 		result.should.equal("bar");
 	});
 
@@ -93,7 +93,7 @@ describe("possessiveExpression", function () {
 	it("can set basic attributes", function () {
 		var div = make("<div data-foo='bar'></div>");
 		var result = evalHyperScript("set foo's [@data-foo] to 'blah'", {
-			foo: div,
+			locals: { foo: div, }
 		});
 		div.getAttribute("data-foo").should.equal("blah");
 	});
@@ -107,7 +107,7 @@ describe("possessiveExpression", function () {
 
 	it("can access basic style", function () {
 		var div = make("<div style='color:red'></div>");
-		var result = evalHyperScript("foo's *color", { foo: div });
+		var result = evalHyperScript("foo's *color", { locals: { foo: div } });
 		result.should.equal("red");
 	});
 
@@ -131,7 +131,7 @@ describe("possessiveExpression", function () {
 
 	it("can set basic styles", function () {
 		var div = make("<div style='color:red'></div>");
-		var result = evalHyperScript("set foo's *color to 'blue'", {foo: div});
+		var result = evalHyperScript("set foo's *color to 'blue'", { locals: { foo: div } });
 		div.style["color"].should.equal("blue");
 	});
 

--- a/test/expressions/propertyAccess.js
+++ b/test/expressions/propertyAccess.js
@@ -1,6 +1,6 @@
 describe("propertyAccess", function () {
 	it("can access basic properties", function () {
-		var result = evalHyperScript("foo.foo", { foo: { foo: "foo" } });
+		var result = evalHyperScript("foo.foo", { locals: { foo: { foo: "foo" } } });
 		result.should.equal("foo");
 	});
 
@@ -10,20 +10,20 @@ describe("propertyAccess", function () {
 	});
 
 	it("of form works", function () {
-		var result = evalHyperScript("foo of foo", { foo: { foo: "foo" } });
+		var result = evalHyperScript("foo of foo", { locals: { foo: { foo: "foo" } } });
 		result.should.equal("foo");
 	});
 
 	it("of form works w/ complex left side", function () {
 		var result = evalHyperScript("bar.doh of foo", {
-			foo: { bar: { doh: "foo" } },
+			locals: { foo: { bar: { doh: "foo" } } }
 		});
 		result.should.equal("foo");
 	});
 
 	it("of form works w/ complex right side", function () {
 		var result = evalHyperScript("doh of foo.bar", {
-			foo: { bar: { doh: "foo" } },
+			locals: { foo: { bar: { doh: "foo" } } }
 		});
 		result.should.equal("foo");
 	});

--- a/test/expressions/queryRef.js
+++ b/test/expressions/queryRef.js
@@ -73,7 +73,7 @@ describe("the queryRef expression", function () {
 				"                  <div foo='bar' class='c2'></div>" +
 				"                  <div class='c3'></div>"
 		);
-		var value = evalHyperScript("<[foo='${x}']/>", { x: "bar" });
+		var value = evalHyperScript("<[foo='${x}']/>", { locals: { x: "bar" } });
 		Array.from(value).length.should.equal(1);
 	});
 
@@ -81,14 +81,14 @@ describe("the queryRef expression", function () {
 		var div = make(
 			"<div id='t1'></div>" + "                  <div id='t2'></div>" + "                  <div id='t3'></div>"
 		);
-		var value = evalHyperScript("<#$id/>", { id: "t2" });
+		var value = evalHyperScript("<#$id/>", { locals: { id: "t2" } });
 		Array.from(value)[0].should.equal(byId("t2"));
 	});
 
 	it("can interpolate elements into queries", function () {
 		var a = make("<div class='a'></div>");
 		var b = make("<div class='b'></div>");
-		var value = evalHyperScript("<${a} + div/>", { a });
+		var value = evalHyperScript("<${a} + div/>", { locals: { a } });
 		Array.from(value)[0].should.equal(b);
 	});
 

--- a/test/expressions/strings.js
+++ b/test/expressions/strings.js
@@ -53,7 +53,7 @@ describe("the string expression", function () {
 		};
 		var result = evalHyperScript(
 			'`<div age="${record.age}" style="color:${record.favouriteColour}">${record.name}</div>`',
-			{ record: record }
+			{ locals: { record: record } }
 		);
 		result.should.equal('<div age="21" style="color:bleaux">John Connor</div>');
 	});

--- a/test/expressions/symbol.js
+++ b/test/expressions/symbol.js
@@ -1,11 +1,11 @@
 describe("the symbol expression", function () {
 	it("resolves local context properly", function () {
-		var result = evalHyperScript("foo", { foo: 42 });
+		var result = evalHyperScript("foo", { locals: { foo: 42 } });
 		result.should.equal(42);
 	});
 
 	it("resolves global context properly", function () {
-		var result = evalHyperScript("document", { foo: 42 });
+		var result = evalHyperScript("document", { locals : { foo: 42 } });
 		result.should.equal(document);
 	});
 });

--- a/test/templates/templates.js
+++ b/test/templates/templates.js
@@ -2,8 +2,10 @@ describe("Templating", function () {
 	it("can render", function () {
 		var tmpl = make("<template>render ${x}</template>");
 		_hyperscript("render tmpl with (x: x) then put it into window.res", {
-			x: ":)",
-			tmpl: tmpl,
+			locals: {
+				x: ":)",
+				tmpl: tmpl,
+			}
 		});
 		window.res.should.equal("render :)");
 		delete window.res;
@@ -12,8 +14,10 @@ describe("Templating", function () {
 	it("escapes html, with opt-out", function () {
 		var tmpl = make("<template>render ${x} ${unescaped x}</template>");
 		_hyperscript("render tmpl with (x: x) then put it into window.res", {
-			x: "<br>",
-			tmpl: tmpl,
+			locals: {
+				x: "<br>",
+				tmpl: tmpl,
+			}
 		});
 		window.res.should.equal("render &lt;br&gt; <br>");
 		delete window.res;
@@ -24,8 +28,10 @@ describe("Templating", function () {
 			"<template>" + "begin\n" + "@repeat in [1, 2, 3]\n" + "${it}\n" + "@end\n" + "end\n" + "</template>"
 		);
 		_hyperscript("render tmpl with (x: x) then put it into window.res", {
-			x: ":)",
-			tmpl: tmpl,
+			locals: {
+				x: ":)",
+				tmpl: tmpl,
+			}
 		});
 		window.res.should.equal("begin\n1\n2\n3\nend\n");
 		delete window.res;
@@ -36,8 +42,10 @@ describe("Templating", function () {
 			"<template>" + "begin\n" + "@if true\n" + "a\n" + "@else\n" + "b\n" + "@end\n" + "end\n" + "</template>"
 		);
 		_hyperscript("render tmpl with (x: x) then put it into window.res", {
-			x: ":)",
-			tmpl: tmpl,
+			locals: {
+				x: ":)",
+				tmpl: tmpl,
+			}
 		});
 		window.res.should.equal("begin\na\nend\n");
 		delete window.res;


### PR DESCRIPTION
Currently local variables are stored directly on `context`. This PR moves those values into a new object, `context.locals`.

In the current strategy the direct assignment of local variables to `context` aligns the usage with changing normal JS object properties, e.g. Element properties, style properties. So these two examples currently work the same way:

`set x to 5` is equivalent to `context['x'] = 5`
`set body's innerHTML to 'hello'` is equivalent `body['innerHTML'] = 'hello'`.

This PR changes the implementation of the first example, and only the first one, to be equivalent to `context.locals['x'] = 5`.

To differentiate the context from other objects, this PR adds `context.meta.__hs_context = true` to each context.

Also changes template plugin to add an entry to `context.meta` instead of adding a local variable.

Happy to talk about or make any requested changes to this PR.