### PR TITLE
Improved comment ergonomics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ it is a companion project of <https://htmx.org>
 
 ```html
 
-<script src="https://unpkg.com/hyperscript.org@0.9.5"></script>
+<script src="https://unpkg.com/hyperscript.org@0.9.6"></script>
 
 
 <button _="on click toggle .clicked">

--- a/test/core/parser.js
+++ b/test/core/parser.js
@@ -30,15 +30,70 @@ describe("the _hyperscript parser", function () {
 				"def foo() -- this is another comment\n" +
 				'  return "foo"\n' +
 				"end -- end with a comment" +
+				"--- this is a comment\n" +
+				"----this is a comment----\n" +
+				"def bar() ---this is another comment\n" +
+				'  return "bar"\n' +
+				"end --- end with a comment" +
+				"</script>"
+		);
+		foo().should.equal("foo");
+		bar().should.equal("bar");
+		delete window.foo;
+		delete window.bar;
+	});
+
+	it("can have comments in attributes", function () {
+		var div = make(
+			"<div _='on click put \"clicked\" into my.innerHTML -- put some content into the div...'></div>"
+		);
+		div.click();
+		div.innerText.should.equal("clicked");
+		var div = make(
+			"<div _='on click put \"clicked\" into my.innerHTML ---put some content into the div...'></div>"
+		);
+		div.click();
+		div.innerText.should.equal("clicked");
+	});
+
+	it("can have alternate comments in scripts", function () {
+		var script = make(
+			"<script type='text/hyperscript'>" +
+				"// this is a comment\n" +
+				"def foo() // this is another comment\n" +
+				'  return "foo"\n' +
+				"end // end with a comment" +
 				"</script>"
 		);
 		foo().should.equal("foo");
 		delete window.foo;
 	});
 
-	it("can have comments in attributes", function () {
+	it("can have alternate comments in attributes", function () {
 		var div = make(
-			"<div _='on click put \"clicked\" into my.innerHTML -- put some content into the div...'></div>"
+			"<div _='on click put \"clicked\" into my.innerHTML // put some content into the div...'></div>"
+		);
+		div.click();
+		div.innerText.should.equal("clicked");
+	});
+
+	it("can have alternate multiline comments in scripts", function () {
+		var script = make(
+			"<script type='text/hyperscript'>" +
+				"/* this is a comment\n" +
+				"this is still a comment */\n" +
+				"def foo() /* this is another comment */\n" +
+				'  return "foo"\n' +
+				"end /* end with a multiline comment \n */" +
+				"</script>"
+		);
+		foo().should.equal("foo");
+		delete window.foo;
+	});
+
+	it("can have multiline comments in attributes", function () {
+		var div = make(
+			"<div _='on click put \"clicked\" into my.innerHTML /* put some content\n into the div... */'></div>"
 		);
 		div.click();
 		div.innerText.should.equal("clicked");

--- a/test/core/tokenizer.js
+++ b/test/core/tokenizer.js
@@ -50,6 +50,17 @@ describe("the _hyperscript tokenizer", function () {
 		lexer.tokenize("-- asdf").list.length.should.equal(0);
 		lexer.tokenize("--\nasdf").list.length.should.equal(1);
 		lexer.tokenize("--\nasdf--").list.length.should.equal(1);
+		lexer.tokenize("---asdf").list.length.should.equal(0);
+		lexer.tokenize("----\n---asdf").list.length.should.equal(0);
+		lexer.tokenize("----asdf----").list.length.should.equal(0);
+		lexer.tokenize("---\nasdf---").list.length.should.equal(1);
+		lexer.tokenize("//asdf").list.length.should.equal(0);
+		lexer.tokenize("asdf//").list.length.should.equal(1);
+		lexer.tokenize("asdf\n//").list.length.should.equal(2);
+		lexer.tokenize("/**/asdf").list.length.should.equal(1);
+		lexer.tokenize("/*asdf*/").list.length.should.equal(0);
+		lexer.tokenize("/*\nasdf\n*/").list.length.should.equal(0);
+		lexer.tokenize("asdf/*\n*/").list.length.should.equal(1);
 	});
 
 	it("handles class identifiers properly", function () {

--- a/www/docs.md
+++ b/www/docs.md
@@ -77,8 +77,8 @@ Embedding code directly on the button like this might seem strange at first, but
 of technologies that de-emphasize [Separation of Concerns](https://en.wikipedia.org/wiki/Separation_of_concerns)
 in favor of [Locality of Behavior](https://htmx.org/essays/locality-of-behaviour/).
 
-Other examples of libraries going this direction are [tailwinds](https://tailwindcss.com/),
-[AlpineJS](https://github.com/alpinejs/alpine/) and [htmx](https://htmx.org).
+Other examples of libraries going this direction are [Tailwind CSS](https://tailwindcss.com/),
+[AlpineJS](https://alpinejs.dev) and [htmx](https://htmx.org).
 
 The next thing you will notice about hyperscript is its syntax, which is very different than most programming languages
 used today. Hyperscript is part of the [xTalk](https://en.wikipedia.org/wiki/XTalk) family of scripting languages, which
@@ -112,7 +112,7 @@ OK, let's get started with hyperscript!
 Hyperscript is a dependency-free javascript library that can be included in a web page without any build step:
 
   ~~~ html
-  <script src="https://unpkg.com/hyperscript.org@0.9.5"></script>
+  <script src="https://unpkg.com/hyperscript.org@0.9.6"></script>
   ~~~
 
 After you've done this, you can begin adding hyperscript to elements:
@@ -375,7 +375,7 @@ Another funny thing you might have noticed is the appearnce of `the` in this scr
 
 `the` is whitespace before any expression in hyperscript and can be used to make your code read more nicely.
 
-For example, if we wanted to use `result` rather than it, we would writ it `the result` instead, which reads more nicely:
+For example, if we wanted to use `result` rather than it, we would write `the result` instead, which reads more nicely:
 
 {% example "The" %}
 <button _="on click increment :x then put the result into the next <output/>">

--- a/www/index.md
+++ b/www/index.md
@@ -31,7 +31,7 @@ hyperscript makes writing event handlers and highly
 responsive user interfaces easy with a clear, DOM-oriented syntax and by transparently
  handling asynchronous behavior for you &mdash; easier than callbacks, promises, even async/await.
 
-Install: `<script src="https://unpkg.com/hyperscript.org@0.9.5"></script>`{.language-html}
+Install: `<script src="https://unpkg.com/hyperscript.org@0.9.6"></script>`{.language-html}
 
 
 ## features

--- a/www/posts/2022-07-12-hyperscript-0.9.6-is-released.md
+++ b/www/posts/2022-07-12-hyperscript-0.9.6-is-released.md
@@ -2,7 +2,7 @@
 layout: layout.njk
 tags: post
 title: hyperscript 0.9.6 has been released!
-date: 2022-02-22
+date: 2022-07-12
 ---
 
 ## hyperscript 0.9.6 Release


### PR DESCRIPTION
# What advantages does this bring?

* Introduces more flexible comment types (`---` `//` `/* */`)
  * Less friction for adoption of Hyperscript for Javascript developers and teams. Bring more people in!
  * Enables far more gradual migrations.
    * Migrate individual lines of code from javascript to hyperscript "in-place". Shared comment style is highly underrated for this.
  * Multi-line comments will provide many other major wins to Hyperscript:
    * Easier debugging by allowing you to "block out" problematic code.
    * Less syntax wordiness when writing documentation comments.
* Refactor: `charAfterThat()` ➡ `nextCharAt(number)`
  * Optionally specify the number of chars to look ahead. 
  * Better naming consistency with `nextChar()`

# Details
Adds 3 new comment types: 
* `---`
  * Allow more than two dashes to be a comment without clashing with [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) / double dash prefixed CSS properties. (`---` or more seems reasonable to avoid clashing)
  * Allows for structural horizontal comments like: `---------------------------`
* `//` 
  * Eases learning curve and decreases friction transitioning to hyperscript.
* `/* ...multi-line... */`
  * Gives hyperscript a multiline comment. Assists in migration of javascript codebases, debugging, documentation comments, etc.

# Resolves Issues

* #292
  * @benpate  
* #265

