### PR TITLE
Docs: Better Javascript to Hyperscript migration docs.

### DIFF
--- a/www/docs.md
+++ b/www/docs.md
@@ -1817,6 +1817,44 @@ So, if you wanted to invoke a method that returns a promise, say `returnsAPromis
 Hyperscript will immediately put the value "I called it..." into the next output element, even if the result
 from `returnsAPromise()` has not yet resolved.
 
+## Using Javascript {#js-migration}
+
+Hyperscript is directly integrated with Javascript, providing ways to use them side by side and migrate with ease.
+
+### Shared Comment Syntax {#js-comments}
+
+`//` and `/* ... */` comments are supported, and ideal for migrating lines of code from Javascript to Hyperscript "in-place". The multi-line comment may be used to "block out" code and write documentation comments.
+
+### Calling Javascript {#js-call}
+
+Any Javascript function may be called directly from Hyperscript. See: [calling functions](#calling-functions).
+
+### Inline Javascript {#js-inline}
+
+Inline Javascript may be defined using the [`js` keyword](/features/js). You might do this for performance reasons,
+since the Hyperscript runtime is more focused on flexibility, rather than performance.
+
+This feature is useful in [workers](#workers), when you want to pass javascript across to the worker's
+implementation:
+
+  ~~~ html
+  <script type="text/hyperscript">
+    worker CoinMiner
+      js
+        function mineNext() {
+          // a javascript implementation...
+        }
+      end
+      def nextCoin()
+        return mineNext()
+      end
+    end
+  </script>
+  ~~~
+
+Note that there is also a way to include [inline javascript](/commands/js)
+directly within a hyperscript body, for local optimizations.
+
 ## Advanced Features {#advanced-features}
 
 We have covered the basics (and not-so-basics) of hyperscript.  Now we come to the more advanced
@@ -1934,32 +1972,6 @@ Here is an example event source in hyperscript:
 
 This event source will put all `message` events in to the `#div` and will log when an `open` event occurs.
 This feature also publishes events, too, so you can listen for Server Sent Events from other parts of your code.
-
-### Inline JS {#js}
-
-Inline javascript may be defined using the [`js` keyword](/features/js). You might do this for performance reasons,
-since the hyperscript runtime is more focused on flexibility, rather than performance.
-
-This feature is useful in [workers](#workers), when you want to pass javascript across to the worker's
-implementation:
-
-  ~~~ html
-  <script type="text/hyperscript">
-    worker CoinMiner
-      js
-        function mineNext() {
-          // a javascript implementation...
-        }
-      end
-      def nextCoin()
-        return mineNext()
-      end
-    end
-  </script>
-  ~~~
-
-Note that there is also a way to include [inline javascript](/commands/js)
-directly within a hyperscript body, for local optimizations.
 
 ## Debugging {#debugging}
 

--- a/www/docs.md
+++ b/www/docs.md
@@ -1829,10 +1829,39 @@ Hyperscript is directly integrated with Javascript, providing ways to use them s
 
 Any Javascript function may be called directly from Hyperscript. See: [calling functions](#calling-functions).
 
+  ~~~ html
+  <button _="on click call alert('Hello from Javascript!')">
+    Click me.
+  </button>
+  ~~~
+
 ### Inline Javascript {#js-inline}
 
-Inline Javascript may be defined using the [`js` keyword](/features/js). You might do this for performance reasons,
-since the Hyperscript runtime is more focused on flexibility, rather than performance.
+Inline Javascript may be defined using the [`js` keyword](/features/js).
+
+  ~~~ html
+  <div _="init js alert('Hello from Javascript!') end"></div>
+  ~~~
+
+Return values are supported.
+
+  ~~~ html
+  <button _="on click js return 'Success!' end then put it into my.innerHTML">
+   Click me.
+  </button>
+  ~~~
+
+Parameters are supported.
+
+  ~~~ html
+  <button _="on click set foo to 1 js(foo) alert('Adding 1 to foo: '+(foo+1)) end">
+   Click me.
+  </button>
+  ~~~
+
+Javascript at the top-level may be defined using the same [`js` command](/commands/js), exposing it to the global scope.
+
+You may use inline Javascript for performance reasons, since the Hyperscript runtime is more focused on flexibility, rather than performance.
 
 This feature is useful in [workers](#workers), when you want to pass javascript across to the worker's
 implementation:
@@ -1851,9 +1880,6 @@ implementation:
     end
   </script>
   ~~~
-
-Note that there is also a way to include [inline javascript](/commands/js)
-directly within a hyperscript body, for local optimizations.
 
 ## Advanced Features {#advanced-features}
 


### PR DESCRIPTION
Directly addresses:
* https://news.ycombinator.com/item?id=32085561

Greatly improves the existing "Inline Javascript" section, puts all the applicable information in one place.