### PR TITLE
Add dist folder to package so it’s included in an npm install (fixes #370)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "files": [
     "LICENSE",
     "README.md",
-    "src/*"
+    "src/*",
+    "dist/*"
   ],
   "main": "dist/_hyperscript.min.js",
   "bin": {


### PR DESCRIPTION
Simply adds `dist/` to `files` in `package.json`.

I’m not familiar with your release process so I’m not sure if this messes anything else up. I’m assuming the files under the git repo under _dist/_ are always the latest builds.

Fixes #370 