### PR TITLE
Resolves #333 by implementing support for scientific notation

### DIFF
--- a/src/_hyperscript.js
+++ b/src/_hyperscript.js
@@ -453,12 +453,35 @@
             function consumeNumber() {
                 var number = makeToken("NUMBER");
                 var value = consumeChar();
+
+                // given possible XXX.YYY(e|E)[-]ZZZ consume XXX
                 while (Lexer.isNumeric(currentChar())) {
                     value += consumeChar();
                 }
+
+                // consume .YYY
                 if (currentChar() === "." && Lexer.isNumeric(nextChar())) {
                     value += consumeChar();
                 }
+                while (Lexer.isNumeric(currentChar())) {
+                    value += consumeChar();
+                }
+
+                // consume (e|E)[-]
+                if (currentChar() === "e" || currentChar() === "E") {
+                    // possible scientific notation, e.g. 1e6 or 1e-6
+                    if (Lexer.isNumeric(nextChar())) {
+                        // e.g. 1e6
+                        value += consumeChar();
+                    } else if (nextChar() === "-") {
+                        // e.g. 1e-6
+                        value += consumeChar();
+                        // consume the - as well since otherwise we would stop on the next loop
+                        value += consumeChar();
+                    }
+                }
+
+                // consume ZZZ
                 while (Lexer.isNumeric(currentChar())) {
                     value += consumeChar();
                 }

--- a/test/core/tokenizer.js
+++ b/test/core/tokenizer.js
@@ -13,6 +13,26 @@ describe("the _hyperscript tokenizer", function () {
 		token.type.should.equal("NUMBER");
 		tokens.hasMore().should.equal(false);
 
+		var tokens = lexer.tokenize("1e6");
+		var token = tokens.consumeToken();
+		token.type.should.equal("NUMBER");
+		tokens.hasMore().should.equal(false);
+
+		var tokens = lexer.tokenize("1e-6");
+		var token = tokens.consumeToken();
+		token.type.should.equal("NUMBER");
+		tokens.hasMore().should.equal(false);
+
+		var tokens = lexer.tokenize("1.1e6");
+		var token = tokens.consumeToken();
+		token.type.should.equal("NUMBER");
+		tokens.hasMore().should.equal(false);
+
+		var tokens = lexer.tokenize("1.1e-6");
+		var token = tokens.consumeToken();
+		token.type.should.equal("NUMBER");
+		tokens.hasMore().should.equal(false);
+
 		var token = lexer.tokenize(".a").consumeToken();
 		token.type.should.equal("CLASS_REF");
 
@@ -204,6 +224,22 @@ describe("the _hyperscript tokenizer", function () {
 		var token = lexer.tokenize("1234567890.1234567890").consumeToken();
 		token.type.should.equal("NUMBER");
 		token.value.should.equal("1234567890.1234567890");
+
+		var token = lexer.tokenize("1e6").consumeToken();
+		token.type.should.equal("NUMBER");
+		token.value.should.equal("1e6");
+
+		var token = lexer.tokenize("1e-6").consumeToken();
+		token.type.should.equal("NUMBER");
+		token.value.should.equal("1e-6");
+
+		var token = lexer.tokenize("1.1e6").consumeToken();
+		token.type.should.equal("NUMBER");
+		token.value.should.equal("1.1e6");
+
+		var token = lexer.tokenize("1.1e-6").consumeToken();
+		token.type.should.equal("NUMBER");
+		token.value.should.equal("1.1e-6");
 
 		var tokens = lexer.tokenize("1.1.1").list;
 		tokens[0].type.should.equal("NUMBER");

--- a/test/expressions/numbers.js
+++ b/test/expressions/numbers.js
@@ -9,6 +9,18 @@ describe("the number expression", function () {
 		var result = evalHyperScript("1.1");
 		result.should.equal(1.1);
 
+		var result = evalHyperScript("1e6");
+		result.should.equal(1e6);
+
+		var result = evalHyperScript("1e-6");
+		result.should.equal(1e-6);
+
+		var result = evalHyperScript("1.1e6");
+		result.should.equal(1.1e6);
+
+		var result = evalHyperScript("1.1e-6");
+		result.should.equal(1.1e-6);
+
 		var result = evalHyperScript("1234567890.1234567890");
 		result.should.equal(1234567890.123456789);
 	});


### PR DESCRIPTION
This commit allows native consumption of numbers written in scientific notation, e.g. 1e6 without using the workaround of `"1e6" as Float`.