### PR TITLE
Added support for classes with leading hyphens

### DIFF
--- a/src/_hyperscript.js
+++ b/src/_hyperscript.js
@@ -247,7 +247,7 @@
                     } else if (
                         !possiblePrecedingSymbol() &&
                         currentChar() === "." &&
-                        (Lexer.isAlpha(nextChar()) || nextChar() === "{")
+                        (Lexer.isAlpha(nextChar()) || nextChar() === "{" || nextChar() === "-")
                     ) {
                         tokens.push(consumeClassReference());
                     } else if (

--- a/test/expressions/classRef.js
+++ b/test/expressions/classRef.js
@@ -41,4 +41,10 @@ describe("the classRef expression", function () {
 		Array.from(value)[0].should.equal(div);
 	});
 
+	it("leading minus class ref works", function () {
+        var div = make("<div class='-c1'></div>");
+        var value = evalHyperScript(".-c1");
+        Array.from(value)[0].should.equal(div);
+    });
+
 });


### PR DESCRIPTION
Now Tailwind classes like `-transform-x-5` work as expected.

Credit goes to YesOperator on the Discord.