### PR TITLE
Fix document.currentScript.src accessed in module

### DIFF
--- a/src/_hyperscript.js
+++ b/src/_hyperscript.js
@@ -2298,7 +2298,7 @@
 
         /** @type string | null */
         // @ts-ignore
-        hyperscriptUrl = "document" in globalScope ? document.currentScript.src : null;
+        hyperscriptUrl = "document" in globalScope && document.currentScript ? document.currentScript.src : null;
     }
 
     class Context {


### PR DESCRIPTION
`document.currentScript.src` can only be accessed when a JS `<script>` is *not* a module. In this case, `document.currentScript` is `null`, and so accessing `.src` results in an error. See [MDN's `currentScript` docs](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)

This PR simply avoids the error. It does NOT set `hyperscriptUrl` in that case, which will cause that to not be set for the web worker extension. I do not use workers, so I did not attempt to validate that this PR does not break the worker extension.

According to the docs linked above, [`import.meta`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta)'s `url` property should theoretically be able to replace that, but I didn't verify this in any way.