### PR TITLE
Fix attribute assignment syntax error

### DIFF
--- a/www/commands/add.md
+++ b/www/commands/add.md
@@ -31,6 +31,8 @@ in `target`.  Note that this clause only works with classes and properties.
 
 <button _="on click add [@disabled=disabled]">Disable Me!</button>
 
+<button _="on click add [@disabled=]">Disable Me Again!</button>
+
 <input
   type="color"
   _="on change add { '--accent-color': my.value } to document.body"

--- a/www/commands/add.md
+++ b/www/commands/add.md
@@ -29,13 +29,13 @@ in `target`.  Note that this clause only works with classes and properties.
 
 <div _="on click add .clacked to #another-div">Click Me!</div>
 
-<button _="on click add @disabled='true'">Disable Me!</button>
+<button _="on click add [@disabled=disabled]">Disable Me!</button>
 
 <input
   type="color"
   _="on change add { '--accent-color': my.value } to document.body"
 />
 
-<button _="on click add @disabled='true' to <button/> when it is not me">Disable Other Buttons</button>
+<button _="on click add [@disabled=disabled] to <button/> when it is not me">Disable Other Buttons</button>
 
 ```


### PR DESCRIPTION
resolves #263

Hi, as written in the above issue, it looks like the current description is not working with a syntax error (maybe due to version up?).

This PR fixes that assignment with the syntax explained in [attribute reference](https://hyperscript.org/expressions/attribute-ref/) page.

Also, I replaced `true` with `disabled` because the `true` is not the valid value specified in the HTML spec, though it's also working in most browsers.

> The values "true" and "false" are not allowed on boolean attributes. To represent a false value, the attribute has to be omitted altogether.

source: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes

Also, I added another example:

```html
<button _="on click add [@disabled=]">Disable Me Again!</button>
```

This shows how to add an empty value like `<button disabled="">`. It took me some time to find it so it would be helpful to others.