### PR TITLE
Docs: fix window.location.reload examples

### DIFF
--- a/www/commands/pseudo-commands.md
+++ b/www/commands/pseudo-commands.md
@@ -18,11 +18,11 @@ looked up on the value returned by the expression and executed.
 
 ### Examples
 
-Consider the `refresh()` method found on `window.location`. In hyperscript, you can use it as a pseudo-command like so:
+Consider the `reload()` method found on `window.location`. In hyperscript, you can use it as a pseudo-command like so:
 
 ```html
-<button _="on click refresh() the location of the window">
-  Refresh the Location
+<button _="on click reload() the location of the window">
+  Reload the Location
 </button>
 
 <button _="on click setAttribute('foo', 'bar') on me">

--- a/www/docs.md
+++ b/www/docs.md
@@ -858,7 +858,7 @@ Finally, you can use the [`pseudo-command`](/commands/pseudo-commands)` syntax, 
 name first on the line in a method call, to improve readability in some cases:
 
   ~~~ hyperscript
-  refresh() the location of the window
+  reload() the location of the window
   writeText('evil') into the navigator's clipboard
   reset() the #contact-form
   ~~~

--- a/www/expressions.md
+++ b/www/expressions.md
@@ -331,16 +331,16 @@ since milliseconds is the normal interpretation for things like `setTimeout()`, 
 The [`of`](/expressions/of) expression allows you to reverse the normal object oriented syntax and write logic in more natural english
 
 ```html
-  <button _="on click call window.location.refresh()">
-    Refresh the Location
+  <button _="on click call window.location.reload()">
+    Reload the Location
   </button>
 ```
 
 Can be rewritten like this:
 
 ```html
-  <button _="on click refresh() the location of the window">
-    Refresh the Location
+  <button _="on click reload() the location of the window">
+    Reload the Location
   </button>
 ```
 

--- a/www/expressions/of.md
+++ b/www/expressions/of.md
@@ -17,16 +17,16 @@ The `of` expression allows you to reverse the normal order of property accessors
 So this:
 
 ```html
-<button _="on click call window.location.refresh()">
-  Refresh the Location
+<button _="on click call window.location.reload()">
+  Reload the Location
 </button>
 ```
 
 Can be rewritten like this:
 
 ```html
-<button _="on click refresh() the location of the window">
-  Refresh the Location
+<button _="on click reload() the location of the window">
+  Reload the Location
 </button>
 ```
 


### PR DESCRIPTION
Some examples in the docs were showing how to refresh the current web page using the `window.location.refresh` method. However, the actual method is `reload` (ref: https://developer.mozilla.org/fr/docs/Web/API/Location/reload).

This PR just fixes them accordingly 🙂 I've left out `docs_old.md`, as it seems to be a backup file, but I can apply the change there if needed too. 