### PR TITLE
[Website] Fix race condition where highlighters only load sometimes.

### DIFF
--- a/www/_includes/layout.njk
+++ b/www/_includes/layout.njk
@@ -11,13 +11,13 @@ title: ///_hyperscript
     <link rel="stylesheet" href="https://the.missing.style/v0.2.1/missing-prism.min.css"/>
     <link rel="stylesheet" href="/css/site.css"/>
     {# <link rel="stylesheet" href="/css/prism-htmx.css"/> #}
-    <script async src="https://unpkg.com/prismjs@1.25.0/components/prism-core.min.js"></script>
-    <script async src="https://unpkg.com/prismjs@1.25.0/plugins/autoloader/prism-autoloader.min.js"></script>
-    <script async src="https://unpkg.com/prismjs@1.25.0/components/prism-markup.min.js"></script>
-    <script async src="https://unpkg.com/prismjs@1.25.0/components/prism-clike.min.js"></script>
-    <script async src="https://unpkg.com/prismjs@1.25.0/components/prism-javascript.min.js"></script>
-    <script async src="https://unpkg.com/prism-hyperscript@1.1.1/prism-hyperscript.js"></script>
-    <script defer src="/js/_hyperscript_w9y.min.js"></script>
+    <script src="https://unpkg.com/prismjs@1.25.0/components/prism-core.min.js"></script>
+    <script src="https://unpkg.com/prismjs@1.25.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://unpkg.com/prismjs@1.25.0/components/prism-markup.min.js"></script>
+    <script src="https://unpkg.com/prismjs@1.25.0/components/prism-clike.min.js"></script>
+    <script src="https://unpkg.com/prismjs@1.25.0/components/prism-javascript.min.js"></script>
+    <script src="https://unpkg.com/prism-hyperscript@1.1.1/prism-hyperscript.js"></script>
+    <script src="/js/_hyperscript_w9y.min.js"></script>
 </head>
 <body>
 <header class="navbar">


### PR DESCRIPTION
### Why?

Unfortunately `async` and `defer` is causing a race.

The result is:
* page highlighters randomly break or only partially highlight on some visits.
* hyperscript.js breaks randomly...

Removed the `async` and `defer`.