### PR TITLE
[Website] Alternative PR for #424. Install line wrap fix. Working example for newbies.

### DIFF
--- a/www/index.md
+++ b/www/index.md
@@ -58,12 +58,12 @@ on pointerdown
 </div>
 
 
-<div style="flex-basis: 100%; text-align: center;"><span id="install"><strong>Install:</strong> <code style="border: 2px dotted #00000055; margin: 0 10px; padding: 4px 6px; border-radius: 4px">&lt;script src="https://unpkg.com/hyperscript.org@0.9.8"&gt;&lt;/script&gt;</code>
-<button style="font:inherit;font-size:.8em;background:#3465a4;color:white;border:none;padding: 0 .4em; border-radius: .4em" _="on click
+<div style="flex-basis: 100%; text-align: center;"><span id="install"><strong>Install:</strong> <code style="border: 2px dotted #00000055; margin: 0 10px; padding: 5px 8px; border-radius: 4px; line-break: anywhere; line-height: 2rem;">&lt;script src="https://unpkg.com/hyperscript.org@0.9.8"&gt;&lt;/script&gt;</code>
+<button style="font:inherit; font-size:.8em; background:#3465a4; color:white; border:none; padding: 0.25em 0.5em; border-radius: .4em" _="on click
   writeText(my previousElementSibling's innerText) on navigator.clipboard
-  put 'copied!' into me
+  put '🎉 Copied' into me
   wait 1s
-  put 'copy' into me">copy</button>
+  put '✂️ Copy' into me">✂️ Copy</button>
 </span>
 
 </div>
@@ -98,7 +98,7 @@ In action ➡️
 </div>
 
 ~~~html
-<button _="on click send hello to <form />">Send</button>
+<button _="on click send hello to <form /> "> Send </button>
 
 <form _="on hello alert('got event')">
 ~~~
@@ -135,7 +135,7 @@ _hyperscript has a super-easy way to write [web workers](/docs#workers).
 ~~~html
 <div _="init js alert('Hello from JavaScript!') end"></div>
 
-<div _="init js(haystack) return /needle/gi.exec(haystack) end">
+<div _="on click js(foo) alert('Adding 1 to foo: '+(foo+1)) end">
 
 <div _="install Draggable(dragHandle: .titlebar)">
 ~~~
@@ -158,7 +158,7 @@ In action ➡️
 ~~~html
 <div _="on click tell <p/> in me add .highlight">
 
-<div _="tell <details /> in .article set you.open to false">
+<div _="on articleClose <details /> in .article set you.open to false">
 ~~~
 
 ## Debugging and extending


### PR DESCRIPTION
If https://github.com/bigskysoftware/_hyperscript/pull/424 isn't being merged, this one should at least go in. Includes the two bugfixes, without restyling other components of the page.

* Install snippet now wraps nicely on line overflow. Little changing icon that congratulates you :tada:
* More "just works" examples for newbies that can be copied/pasted without background knowledge.

![image](https://user-images.githubusercontent.com/24665/231402357-3759bbf1-474d-465a-abb1-f93ebb4e4d39.png)
