### PR TITLE
Implement attribute support for `take` command

### DIFF
--- a/test/commands/take.js
+++ b/test/commands/take.js
@@ -64,4 +64,91 @@ describe("the take command", function () {
 		d2.classList.contains("foo").should.equal(true);
 		d3.classList.contains("foo").should.equal(false);
 	});
+
+	it("can take an attribute from other elements", function () {
+		var d1 = make("<div class='div' data-foo='bar'></div>");
+		var d2 = make("<div class='div' _='on click take @data-foo from .div'></div>");
+		var d3 = make("<div class='div'></div>");
+		d1.getAttribute("data-foo").should.equal("bar");
+		assert.isNull(d2.getAttribute("data-foo"))
+		assert.isNull(d3.getAttribute("data-foo"))
+		d2.click();
+		assert.isNull(d1.getAttribute("data-foo"))
+		d2.getAttribute("data-foo").should.equal("");
+		assert.isNull(d3.getAttribute("data-foo"))
+	});
+
+	it("can take an attribute with specific value from other elements", function () {
+		var d1 = make("<div class='div' data-foo='bar'></div>");
+		var d2 = make("<div class='div' _='on click take @data-foo=baz from .div'></div>");
+		var d3 = make("<div class='div'></div>");
+		d1.getAttribute("data-foo").should.equal("bar");
+		assert.isNull(d2.getAttribute("data-foo"))
+		assert.isNull(d3.getAttribute("data-foo"))
+		d2.click();
+		assert.isNull(d1.getAttribute("data-foo"))
+		d2.getAttribute("data-foo").should.equal("baz");
+		assert.isNull(d3.getAttribute("data-foo"))
+	});
+
+	it("can take an attribute value from other elements and set specific values instead", function () {
+		var d1 = make("<div class='div' data-foo='bar'></div>");
+		var d2 = make("<div class='div' _='on click take @data-foo=baz with \"qux\" from .div'></div>");
+		var d3 = make("<div class='div'></div>");
+
+		d1.getAttribute("data-foo").should.equal("bar");
+		assert.isNull(d2.getAttribute("data-foo"))
+		assert.isNull(d3.getAttribute("data-foo"))
+		d2.click();
+		d1.getAttribute("data-foo").should.equal("qux");
+		d2.getAttribute("data-foo").should.equal("baz");
+		d3.getAttribute("data-foo").should.equal("qux");
+	});
+
+	it("can take an attribute value from other elements and set value from an expression instead", function () {
+		var d1 = make("<div class='div' data-foo='bar'></div>");
+		var d2 = make("<div class='div' data-foo='qux' _='on click take @data-foo=baz with my @data-foo from .div'></div>");
+		var d3 = make("<div class='div'></div>");
+
+		d1.getAttribute("data-foo").should.equal("bar");
+		d2.getAttribute("data-foo").should.equal("qux");
+		assert.isNull(d3.getAttribute("data-foo"))
+		d2.click();
+		d1.getAttribute("data-foo").should.equal("qux");
+		d2.getAttribute("data-foo").should.equal("baz");
+		d3.getAttribute("data-foo").should.equal("qux");
+	});
+
+	it("can take an attribute for other elements", function () {
+		var d1 = make("<div class='div' data-foo='bar'></div>");
+		var d2 = make("<div class='div' _='on click take @data-foo from .div for #d3'></div>");
+		var d3 = make("<div id='d3' class='div'></div>");
+		d1.getAttribute("data-foo").should.equal("bar");
+		assert.isNull(d2.getAttribute("data-foo"))
+		assert.isNull(d3.getAttribute("data-foo"))
+		d2.click();
+		assert.isNull(d1.getAttribute("data-foo"))
+		assert.isNull(d2.getAttribute("data-foo"))
+		d3.getAttribute("data-foo").should.equal("");
+	});
+
+	it("a parent can take an attribute for other elements", function () {
+		var div = make(
+			"<div _='on click take @data-foo from .div for event.target'>" +
+				"<div id='d1' class='div' data-foo='bar'></div>" +
+				"<div id='d2' class='div'></div>" +
+				"<div id='d3' class='div'></div>" +
+			"</div>"
+		);
+		var d1 = byId("d1");
+		var d2 = byId("d2");
+		var d3 = byId("d3");
+		d1.getAttribute("data-foo").should.equal("bar");
+		assert.isNull(d2.getAttribute("data-foo"))
+		assert.isNull(d3.getAttribute("data-foo"))
+		d2.click();
+		assert.isNull(d1.getAttribute("data-foo"))
+		d2.getAttribute("data-foo").should.equal("");
+		assert.isNull(d3.getAttribute("data-foo"))
+	});
 });

--- a/www/commands/take.md
+++ b/www/commands/take.md
@@ -7,13 +7,15 @@ title: take - ///_hyperscript
 ### Syntax
 
 ```ebnf
- take <class-ref> [from <expression>] [for <expression>]
+ take <class-ref or attribute-ref [with <expression>]> [from <expression>] [for <expression>]
 ```
 
 ### Description
 
-The `take` command allows you to take a class from a set of elements (or all elements) and add it to the current element (or the targeted element).
+The `take` command allows you to take a class or an attribute from a set of elements (or all elements) and add it to the current element (or the targeted element).
 
+When using `take` with attributes, elements matching `from` expression will have their attributes with the same name removed regardless of value.
+You can specify a new value to be assigned instead via `with` clause (in this case the attribute will be added even if the element didn't have it originally).
 ### Examples
 
 ```html
@@ -23,5 +25,17 @@ The `take` command allows you to take a class from a set of elements (or all ele
   <a class="tab active">Tab 1</a>
   <a class="tab">Tab 2</a>
   <a class="tab">Tab 3</a>
+</div>
+
+<div _="on click take [@aria-curent=page] from .step for event.target">
+  <a class="step">Step 1</a>
+  <a class="step">Step 2</a>
+  <a class="step">Step 3</a>
+</div>
+
+<div _="on click take [@aria-selected=true] with 'false' from .item for event.target">
+  <a class="item">Option 1</a>
+  <a class="item">Option 2</a>
+  <a class="item">Option 3</a>
 </div>
 ```


### PR DESCRIPTION
Primary use case is manipulation of aria-properties (`aria-selected`, `aria-current`), but obviously can be used with any attribute for any purpose. Inspired by discussion on accessibility in discord/twitter and my own experience implementing drag-n-drop.

Comments on syntax are welcome