### PR TITLE
generate typescript typings on the build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
     "dist/*"
   ],
   "main": "dist/_hyperscript.min.js",
+  "types": "dist/_hyperscript.d.ts",
   "bin": {
     "_hyperscript": "src/bin/node-hyperscript.js"
   },
   "scripts": {
     "test": "mocha-chrome test/index.html",
-    "dist": "cp -r src/* dist/ && npm run-script terser && gzip -k -f dist/_hyperscript.min.js > dist/_hyperscript.min.js.gz && exit",
+    "dist": "cp -r src/* dist/ && npm run-script terser && npm run-script typings && gzip -k -f dist/_hyperscript.min.js > dist/_hyperscript.min.js.gz && exit",
+    "typings": "npx --yes tsc --declaration dist/_hyperscript.js --allowJs --emitDeclarationOnly --skipLibCheck",
     "www": "node scripts/www.js",
     "terser": "terser -m eval dist/_hyperscript.js > dist/_hyperscript.min.js && terser -m eval dist/hdb.js > dist/hdb.min.js"
   },


### PR DESCRIPTION
Currently typescript users for example `AstroJS` importing hyperscript is complicated. The following will throw an error about missing types. 

```ts
import hyperscript from 'hyperscript.org';
hyperscript.browserInit();
```

As we currently see in the repository there already exists an empty type definition file `dist/_hyperscript.d.ts`  So this PR only introduces an additional script command and the path to generated typings

closes #353 