### PR TITLE
Fixed the context where the socket's 'message' symbol is located

### DIFF
--- a/src/socket.js
+++ b/src/socket.js
@@ -180,13 +180,13 @@
 						var context = runtime.makeContext(socketObject, socketFeature, socketObject);
 						if (jsonMessages) {
 							if (dataAsJson) {
-								context.message = dataAsJson;
+								context.locals.message = dataAsJson;
 								context.result = dataAsJson;
 							} else {
 								throw "Received non-JSON message from socket: " + data;
 							}
 						} else {
-							context.message = data;
+							context.locals.message = data;
 							context.result = data;
 						}
 						messageHandler.execute(context);


### PR DESCRIPTION
When I was experimenting with the example code from the documentation, `undefined` would always be logged to the console. (I could confirm with Chrome's developer tools that the messages were indeed coming through)

```hyperscript
socket MySocket ws://myserver.com/example
  on message as json
    log message
end
```

Additionally, if I added the command
```hyperscript
log result
```
it actually logs the message received from the socket.

I did some digging around to try and understand what was going on behind the scenes, and I think adding 'message' to the local context is the correct way forward. Hopefully this is correct!