### PR TITLE
JS-style hex escapes in strings

### DIFF
--- a/src/_hyperscript.js
+++ b/src/_hyperscript.js
@@ -541,6 +541,12 @@
                             value += "\t";
                         } else if (nextChar === "v") {
                             value += "\v";
+                        } else if (nextChar === "x") {
+                            const hex = consumeHexEscape();
+                            if (Number.isNaN(hex)) {
+                                throw Error("Invalid hexadecimal escape at " + Lexer.positionString(string));
+                            }
+                            value += String.fromCharCode(hex);
                         } else {
                             value += nextChar;
                         }
@@ -557,6 +563,23 @@
                 string.end = position;
                 string.template = startChar === "`";
                 return string;
+            }
+
+            /**
+             * @returns number
+             */
+            function consumeHexEscape() {
+                const BASE = 16;
+                if (!currentChar()) {
+                    return NaN;
+                }
+                let result = BASE * Number.parseInt(consumeChar(), BASE);
+                if (!currentChar()) {
+                    return NaN;
+                }
+                result += Number.parseInt(consumeChar(), BASE);
+
+                return result;
             }
 
             /**

--- a/test/core/tokenizer.js
+++ b/test/core/tokenizer.js
@@ -315,6 +315,42 @@ describe("the _hyperscript tokenizer", function () {
 		token.value.should.equal("\v");
 	});
 
+	it("handles hex escapes properly", function () {
+		var lexer = _hyperscript.internals.lexer;
+		var token = lexer.tokenize('"\\x1f"').consumeToken();
+		token.value.should.equal("\x1f");
+
+		token = lexer.tokenize('"\\x41"').consumeToken();
+		token.value.should.equal("A");
+
+		token = lexer.tokenize('"\\x41\\x61"').consumeToken();
+		token.value.should.equal("Aa");
+
+		try {
+			lexer.tokenize('"\\x"').consumeToken();
+		} catch (e) {
+			e.message.indexOf("Invalid hexadecimal escape").should.equal(0);
+		}
+
+		try {
+			lexer.tokenize('"\\xGG"').consumeToken();
+		} catch (e) {
+			e.message.indexOf("Invalid hexadecimal escape").should.equal(0);
+		}
+
+		try {
+			lexer.tokenize('"\\1H"').consumeToken();
+		} catch (e) {
+			e.message.indexOf("Invalid hexadecimal escape").should.equal(0);
+		}
+
+		try {
+			lexer.tokenize('"\\x4"').consumeToken();
+		} catch (e) {
+			e.message.indexOf("Invalid hexadecimal escape").should.equal(0);
+		}
+	});
+
 	it("handles strings properly 2", function () {
 		var lexer = _hyperscript.internals.lexer;
 		var token = lexer.tokenize("'foo'").consumeToken();


### PR DESCRIPTION
I recently found myself needing a hex escape and discovered that _hyperscript doesn't interpret those, forcing me to use something like
```
js return '\x41' end
log it
```

The implementation is trivial and could easily be extended to accomodate full unicode escapes.

```js
// before PR
log '\x41' // x41
// after PR
log '\x41' // A
```