### PR TITLE
update render command documentation to include a note on installation

### DIFF
--- a/www/commands/render.md
+++ b/www/commands/render.md
@@ -4,6 +4,13 @@ title: render - ///_hyperscript
 
 ## The `render` command
 
+### Installing
+
+Note: if you want the template command, you must include the /dist/template.js file in addition to the hyperscript script
+  ~~~ html
+  <script src="https://unpkg.com/hyperscript.org@0.9.12/dist/template.js"></script>
+  ~~~
+
 ### Syntax
 
 `render <template> with (<arg list>)`


### PR DESCRIPTION
The render command is one of the few exceptions that require the inclusion of an additional script file from the distribution to work. This doc update makes it clearer by mentioning that. as discussed in #496 