### PR TITLE
Allow implicitLoop over HTMLCollection/NodeList

### DIFF
--- a/src/_hyperscript.js
+++ b/src/_hyperscript.js
@@ -1555,7 +1555,15 @@
          */
         implicitLoop(value, func) {
             if (this.shouldAutoIterate(value)) {
-                for (const x of value) func(x);
+                for (const x of value) {
+                    if (typeof NodeList !== 'undefined' && (value instanceof NodeList || value instanceof HTMLCollection)) {
+                        for (const y of x) {
+                            func(y);
+                        }
+                    } else {
+                        func(x);
+                    }
+                }
             } else {
                 func(value);
             }


### PR DESCRIPTION
Tried doing `add .class to the children of .list` but couldn't since `children of .list` is a HTMLCollection. Didn't think using `this.isArrayLike` was correct since it also checks for `Array.isArray`