### PR TITLE
Fix incorrect path in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ it is a companion project of <https://htmx.org>
 
 ```html
 
-<script src="https://unpkg.com/hyperscript.org@0.9.7"></script>
+<script src="https://unpkg.com/hyperscript.org@0.9.12"></script>
 
 
 <button _="on click toggle .clicked">

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "main": "dist/_hyperscript.min.js",
   "types": "dist/_hyperscript.d.ts",
   "bin": {
-    "_hyperscript": "src/bin/node-hyperscript.js"
+    "_hyperscript": "src/node-hyperscript.js"
   },
   "scripts": {
     "test": "mocha-chrome test/index.html",

--- a/www/index.md
+++ b/www/index.md
@@ -37,7 +37,7 @@ Enhance HTML with concise DOM, event and async features. **Make writing interact
 ~~~hyperscript
 on pointerdown
   repeat until event pointerup
-    set rand to Math.random() * 255
+    set rand to Math.random() * 360
     transition
       *background-color
       to `hsl($rand 100% 90%)`
@@ -50,7 +50,7 @@ on pointerdown
 <span class="center" style="margin-top: calc(-1.5*var(--gap))"><button class="crowded padding padding-block allcaps" _="
 on pointerdown
   repeat until event pointerup
-    set rand to Math.random() * 255
+    set rand to Math.random() * 360
     transition *background-color
             to `hsl($rand 100% 90%)`
           over 250ms

--- a/www/posts/2023-10-20-hyperscript-0.9.12-is-released.md
+++ b/www/posts/2023-10-20-hyperscript-0.9.12-is-released.md
@@ -1,0 +1,21 @@
+---
+layout: layout.njk
+tags: post
+title: hyperscript 0.9.12 has been released!
+date: 2023-10-20
+---
+
+## hyperscript 0.9.12 Release
+
+We are pleased to present the [0.9.12 release](https://unpkg.com/browse/hyperscript.org@0.9.12/) of hyperscript.
+
+### Changes
+
+* The [take](https://hyperscript.org/commands/take) take command can now take multiple classes at once
+* Typescript bindings are now generated
+* The go command scroll offset has been re-implemented and now works correctly
+* The `message` symbol is properly set in web socket extension
+* hex escapes now work properly in strings
+* `_hyperscript` now includes a `version` property to easily see what version you are on from the console
+
+Enjoy!


### PR DESCRIPTION
Like issue #321 return a error to install with pnpm
```
 WARN  Failed to create bin at /home/aline/Desktop/xx/platform/node_modules/.bin/_hyperscript. ENOENT: no such file or directory, open '/home/aline/Desktop/xxx/platform/node_modules/hyperscript.org/src/bin/node-hyperscript.js'
 WARN  Failed to create bin at /home/aline/Desktop/xxx/platform/node_modules/.bin/_hyperscript. ENOENT: no such file or directory, open '/home/aline/Desktop/xxxx/platform/node_modules/hyperscript.org/src/bin/node-hyperscript.js'
 ```
