### PR TITLE
Docs: Fix typos and broken links

### DIFF
--- a/www/docs.md
+++ b/www/docs.md
@@ -541,7 +541,7 @@ If you wish to assign an identifier to the new object you can use the ` called `
   log myURL
   ~~~
 
-You can also use [`query literals`](/expressions/query_references), discussed [below](#dom_literals), to create new HTML content:
+You can also use [`query literals`](/expressions/#query-literals), discussed [below](#dom-literals), to create new HTML content:
 
   ~~~ hyperscript
   make an <a.navlink/> then put it after me

--- a/www/features/on.md
+++ b/www/features/on.md
@@ -54,7 +54,7 @@ Finally an event can specify a `debounced at` or `throttled at` value to debounc
 Events can be repeated separated by an `or` to assign one handler to multiple events:
 
 ```html
-<div _="on click or touchbegin fetch /example then put it into my innerHTML">
+<div _="on click or touchstart fetch /example then put it into my innerHTML">
   Fetch it...
 </div>
 ```

--- a/www/posts/2021-03-06-hyperscript-0.0.5-is-released.md
+++ b/www/posts/2021-03-06-hyperscript-0.0.5-is-released.md
@@ -82,7 +82,7 @@ to the language.
 
   ```html
   <div
-    _="on mouseenter or touchbegin fetch /content then put it into my.innerHTML"
+    _="on mouseenter or touchstart fetch /content then put it into my.innerHTML"
   >
     Fetch it...
   </div>


### PR DESCRIPTION
- There's no event `touchbegin`, so replacing it in the examples with [touchstart](https://developer.mozilla.org/en-US/docs/Web/API/Element/touchstart_event)

- Fixed up some deadlinks.