### PR TITLE
feat(Syntax addition): to match language style, "for item in myList indexed by i"

### DIFF
--- a/src/_hyperscript.js
+++ b/src/_hyperscript.js
@@ -5627,7 +5627,11 @@
                 }
             }
 
-            if (tokens.matchToken("index")) {
+            if (tokens.matchToken("index") || tokens.matchToken("by")) {
+                var identifierToken = tokens.requireTokenType("IDENTIFIER");
+                var indexIdentifier = identifierToken.value;
+            } else if (tokens.matchToken("indexed")) {
+                tokens.requireToken("by");
                 var identifierToken = tokens.requireTokenType("IDENTIFIER");
                 var indexIdentifier = identifierToken.value;
             }

--- a/src/_hyperscript.js
+++ b/src/_hyperscript.js
@@ -5627,7 +5627,7 @@
                 }
             }
 
-            if (tokens.matchToken("index") || tokens.matchToken("by")) {
+            if (tokens.matchToken("index")) {
                 var identifierToken = tokens.requireTokenType("IDENTIFIER");
                 var indexIdentifier = identifierToken.value;
             } else if (tokens.matchToken("indexed")) {

--- a/test/commands/repeat.js
+++ b/test/commands/repeat.js
@@ -151,16 +151,6 @@ describe("the repeat command", function () {
 		d1.innerHTML.should.equal("a0ab1abc2");
 	});
 
-	it("by syntax works", function () {
-		var d1 = make(
-			'<div _=\'on click repeat for x in ["a", "ab", "abc"] by i' +
-				"                                    put x + i at end of me" +
-				"                                  end'></div>"
-		);
-		d1.click();
-		d1.innerHTML.should.equal("a0ab1abc2");
-	});
-
 	it("while keyword works", function () {
 		make(
 			"" +

--- a/test/commands/repeat.js
+++ b/test/commands/repeat.js
@@ -141,6 +141,26 @@ describe("the repeat command", function () {
 		d1.innerHTML.should.equal("a0ab1abc2");
 	});
 
+	it("indexed by syntax works", function () {
+		var d1 = make(
+			'<div _=\'on click repeat for x in ["a", "ab", "abc"] indexed by i' +
+				"                                    put x + i at end of me" +
+				"                                  end'></div>"
+		);
+		d1.click();
+		d1.innerHTML.should.equal("a0ab1abc2");
+	});
+
+	it("by syntax works", function () {
+		var d1 = make(
+			'<div _=\'on click repeat for x in ["a", "ab", "abc"] by i' +
+				"                                    put x + i at end of me" +
+				"                                  end'></div>"
+		);
+		d1.click();
+		d1.innerHTML.should.equal("a0ab1abc2");
+	});
+
 	it("while keyword works", function () {
 		make(
 			"" +

--- a/www/docs.md
+++ b/www/docs.md
@@ -725,7 +725,7 @@ It supports a large number of variants, including a short hand `for` version:
 
   -- you may use the index clause on any of the above
   -- to bind the loop index to a given symbol
-  -- an index clause is any of "index", "by", or "indexed by"
+  -- an index clause is any of "index", or "indexed by"
   -- followed by a variable name
   for x in [1, 2, 3] index i
     log i, "is", x

--- a/www/docs.md
+++ b/www/docs.md
@@ -725,6 +725,8 @@ It supports a large number of variants, including a short hand `for` version:
 
   -- you may use the index clause on any of the above
   -- to bind the loop index to a given symbol
+  -- an index clause is any of "index", "by", or "indexed by"
+  -- followed by a variable name
   for x in [1, 2, 3] index i
     log i, "is", x
   end


### PR DESCRIPTION
```for item in myList indexed by i```
```for item in myList by i``` Edit: no longer offers this second extra syntax

Support for both of the above index clauses because the normal one reads terribly in a language that otherwise reads amazingly.

The one way to do it before was obviously only

```for item in myList index i```

An example of the new syntax from a project

```
_="
on load put the children of the closest parent <div /> into myList
then for item in myList indexed by i
if the item's index does not exist
set the item's index to i
then set the item's id to item's id + '_' + i
"
```

As opposed to
```
_="
on load put the children of the closest parent <div /> into myList
then for item in myList index i
if the item's index does not exist
set the item's index to i
then set the item's id to item's id + '_' + i
"
```