### PR TITLE
fixing the css selector in the remove close from the docs

### DIFF
--- a/www/docs.md
+++ b/www/docs.md
@@ -1356,7 +1356,7 @@ with the corresponding hyperscript:
 
   ~~~ hyperscript
   on click from #example-btn
-    remove .elements-to-remove
+    remove <.elements-to-remove/>
   ~~~
 
 You can see how the support for CSS literals directly in hyperscript makes for a much cleaner script, allowing us


### PR DESCRIPTION
Hello guys,

I was playing around with hyperscript and I tried to copy and paste this code [from the doc](https://hyperscript.org/docs/#dom-literals):
```
Compare the following JavaScript:

document.querySelector('#example-btn')
  .addEventListener('click', e => {
    document.querySelectorAll(".elements-to-remove").forEach(value => value.remove());
})

with the corresponding hyperscript:

on click from #example-btn
  remove .elements-to-remove
```

However this didn't work. The fix for this was to add the some diamonds around the `.elements-to-remove` like so `<.elements-to-remove/>` to have the expected behaviour.

here is a codepen that shows this: https://codepen.io/tartie2/pen/xxojxNq