### PR TITLE
Add `composed: true` to triggered events

### DIFF
--- a/src/_hyperscript.js
+++ b/src/_hyperscript.js
@@ -1453,6 +1453,7 @@
                 evt = new Event(eventName, {
                     bubbles: true,
                     cancelable: true,
+                    composed: true,
                 });
                 evt['detail'] = detail;
             } else {


### PR DESCRIPTION
Fixes #559 .

If you're using Hyperscript on nodes within a shadow DOM (don't ask, it's  transitional), events won't pass the shadow DOM boundary by default. Adding `composed: true` lets them pass. 

I ran into this issue myself, and it also appears to be the same root cause as #559 .