### PR TITLE
Add FileList to the bag of 'ArrayLikes'.

### DIFF
--- a/src/_hyperscript.js
+++ b/src/_hyperscript.js
@@ -1479,14 +1479,14 @@
 
         /**
          * isArrayLike returns `true` if the provided value is an array or
-         * a NodeList (which is close enough to being an array for our purposes).
+         * something close enough to being an array for our purposes.
          *
          * @param {any} value
-         * @returns {value is Array | NodeList}
+         * @returns {value is Array | NodeList | HTMLCollection | FileList}
          */
         isArrayLike(value) {
             return Array.isArray(value) ||
-                (typeof NodeList !== 'undefined' && (value instanceof NodeList || value instanceof HTMLCollection));
+                (typeof NodeList !== 'undefined' && (value instanceof NodeList || value instanceof HTMLCollection || value instanceof FileList));
         }
 
         /**


### PR DESCRIPTION
This was discussed on discord in the context of the following snippet:

```
on change from #id_files
  set timestamps to the #id_files.files.lastModified
  set #id_timestamp's value to timestamps.join(',')
end
```

It was suggested to just add `FileList` to the "close enough" values for `isArrayLike`, so that we're careful not to accidentally implement iteration over things like `<select>`.