### PR TITLE
fix(docs): fix and update some examples

### DIFF
--- a/www/commands/add.md
+++ b/www/commands/add.md
@@ -36,4 +36,6 @@ in `target`.  Note that this clause only works with classes and properties.
 
 <button _="on click add [@disabled='true'] to <button/> when it is not me">Disable Other Buttons</button>
 
+<button _"on click add .{'-foo-bar'} to #that">Add Class With A Dash Prefix!</button>
+
 ```

--- a/www/commands/add.md
+++ b/www/commands/add.md
@@ -15,8 +15,6 @@ add <class-ref+ or attribute-ref or object-literal> [to <target-expression>] [wh
 The `add` command allows you to add a class (via a [class ref](/expressions/class-reference)), an attribute
 (via an [attribute ref](/expressions/attribute-ref)) or CSS attributes (via an object literal) to either the current element or to another element.
 
-**Note:** Hyperscript supports hyphens in object property names, so you can write `add { font-size: '2em' }`. However, double hyphens (`--`) mark comments in hyperscript, so if you need to use them for [CSS Custom Properties][], use quotes -- `add { '--big-font-size': '2em' }`.
-
 The `where` clause allows you filter what elements have the class or property added in the `target`.  The expression will be evaluated for
 each element in `target` and, if the result is true, the element class or property will be added.  If it is false, the class
 or property will be removed.  The `it` symbol will be set to the current element, allowing you to express conditions against each element
@@ -27,15 +25,15 @@ in `target`.  Note that this clause only works with classes and properties.
 ```html
 <div _="on click add .clicked">Click Me!</div>
 
-<div _="on click add .clacked to #another-div">Click Me!</div>
+<div _="on click add .clicked to #another-div">Click Me!</div>
 
-<button _="on click add @disabled='true'">Disable Me!</button>
+<button _="on click add @disabled">Disable Me!</button>
 
 <input
   type="color"
-  _="on change add { '--accent-color': my.value } to document.body"
+  _="on change add { --accent-color: my.value } to document.body"
 />
 
-<button _="on click add @disabled='true' to <button/> when it is not me">Disable Other Buttons</button>
+<button _="on click add [@disabled='true'] to <button/> when it is not me">Disable Other Buttons</button>
 
 ```

--- a/www/expressions/attribute-ref.md
+++ b/www/expressions/attribute-ref.md
@@ -15,7 +15,11 @@ Attribute references are similar to CSS attribute references, and may or may not
 ### Examples
 
 ```html
-<button _="on click add [@disabled]">Disable Me!</button>
+<button _="on click add @disabled">Disable Me!</button>
 
 <button _="on click remove [@disabled]">Enable Me!</button>
+
+<button type="button" _="on click add [@type='submit']">Change My Type!</button>
+
+<button type="button" _="on click my @type to 'submit'">Change My Type As Well!</button>
 ```

--- a/www/expressions/possessive.md
+++ b/www/expressions/possessive.md
@@ -30,6 +30,6 @@ The possessive expression can also be used to get and set attributes of an eleme
 >
 </div>
 <button _"on click put #foo's @data-demo into me">
-  Replace Me w/ Attribute Data
+  Replace Me w/ Foo's Attribute Data
 </button>
 ```

--- a/www/expressions/possessive.md
+++ b/www/expressions/possessive.md
@@ -25,9 +25,11 @@ The possessive expression can also be used to get and set attributes of an eleme
   Go to Duck Duck Go
 </div>
 <div
+  id="foo"
   data-demo="Here is some data..."
-  _="on click put my attribute data-demo into me"
 >
-  Replace Me w/ Attribute Data
 </div>
+<button _"on click put #foo's @data-demo into me">
+  Replace Me w/ Attribute Data
+</button>
 ```

--- a/www/features/def.md
+++ b/www/features/def.md
@@ -25,9 +25,9 @@ Functions are typically placed in script tags:
 
 ```html
 <script type="text/hyperscript">
-  def delayTheAnswer()
+  def delayTheAnswer(i)
     wait 2s
-    return 42
+    return i
   end
 </script>
 ```


### PR DESCRIPTION
Some examples were outdated and did not run anymore so I fixed them.
I also added some more examples to make things clearer.

As for the `note` removed from the `add` command's docs, it has been made a non-issue with [release 0.8.4](https://hyperscript.org/posts/2021-11-02-hyperscript-0.8.4-is-released/) by adding a space after the `--` in order to make a comment.

Just a note, on the `add` example, this line does not actually add the color picker's value to the element but the string `my.value`.

I doubled check and I can `log my.value` and got a hex.
I didn't know how to fix it but the example is still important to keep so I just left it :)

Talking about this:
```applescript
on change add { --accent-color: my.value } to document.body
```