### PR TITLE
Fix wrong comment symbol used (`#` -> `--`)

### DIFF
--- a/www/docs.md
+++ b/www/docs.md
@@ -714,21 +714,21 @@ Comparisons can be combined via the `and`, `or` and `not` expressions in the usu
 Note that `and` and `or` will short circuit in the normal manner:
 
   ~~~ hyperscript
-  if false and foo() # foo() will not execute
+  if false and foo() -- foo() will not execute
   ~~~
 
 with one important caveat: if the first expression returns a Promise rather than a synchronous value, it will be interpreted
 as truthy:
 
   ~~~ hyperscript
-  if returnsPromise() and foo() # foo() will execute, even if the promise resolves to false
+  if returnsPromise() and foo() -- foo() will execute, even if the promise resolves to false
   ~~~
 
 To work around this, you can move the promise-based value out to a separate statement:
 
   ~~~ hyperscript
   get returnsPromise()
-  if the result and foo() # foo() will not execute if promise resolves to false
+  if the result and foo() -- foo() will not execute if promise resolves to false
   ~~~
 
 #### Loops {#loops}


### PR DESCRIPTION
Some code blocks in the Operator section (#comparisons-%26-logical-operators) used the wrong comment symbol, `#` instead of `--`