### PR TITLE
Add reactive when and bind features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ _site
 *.icloud
 /coverage/
 /tmp/
+.worktrees/

--- a/src/_hyperscript.js
+++ b/src/_hyperscript.js
@@ -101,6 +101,8 @@ import {InstallFeature} from './parsetree/features/install.js';
 import {JsFeature} from './parsetree/features/js.js';
 import {DefFeature} from './parsetree/features/def.js';
 import {OnFeature} from './parsetree/features/on.js';
+import {WhenFeature} from './parsetree/features/when.js';
+import {BindFeature} from './parsetree/features/bind.js';
 
 const globalScope = typeof self !== 'undefined' ? self : (typeof global !== 'undefined' ? global : this);
 
@@ -186,7 +188,8 @@ kernel.addTopExpression("asyncExpression", AsyncExpression.parse);
 // Features
 kernel.addFeatures(
     OnFeature, DefFeature, SetFeature, InitFeature,
-    WorkerFeature, BehaviorFeature, InstallFeature
+    WorkerFeature, BehaviorFeature, InstallFeature,
+    WhenFeature, BindFeature
 );
 kernel.addGrammarElement("jsBody", JsBody.parse);
 kernel.addFeature("js", JsFeature.parse);

--- a/src/core/reactivity.js
+++ b/src/core/reactivity.js
@@ -1,0 +1,439 @@
+// Reactivity - Automatic dependency tracking for _hyperscript
+//
+// When an effect is active, reads via resolveSymbol, resolveProperty,
+// and resolveAttribute record dependencies. Writes via setSymbol
+// notify subscribers. Property and attribute changes are detected
+// via DOM events and MutationObserver.
+
+/**
+ * @typedef {Object} EffectHandle
+ * @property {() => any} computeFn - Tracked computation function
+ * @property {(newValue: any) => void} effectFn - Called when value changes
+ * @property {Map<string, DepRecord>} deps - depKey -> structured record (dedup + data)
+ * @property {any} oldValue - Last computed value (for same-value dedup)
+ * @property {Element|null} element - Owning element (for lifecycle)
+ * @property {boolean} disposed - Whether this effect has been cleaned up
+ * @property {Array<Function>} subscriptions - Active teardown functions
+ * @property {number} _triggerCount - Circular dependency guard counter
+ *
+ * @typedef {Object} DepRecord
+ * @property {string} type - "symbol" | "property" | "attribute"
+ * @property {string} name - Symbol/property/attribute name
+ * @property {string} [scope] - "global" or "element" (for symbol deps)
+ * @property {Element} [element] - Target element (for element-scoped deps)
+ */
+
+export class Reactivity {
+    /**
+     * @param {Object} runtime - The Runtime instance
+     */
+    constructor(runtime) {
+        this.runtime = runtime;
+
+        /** @type {EffectHandle|null} Currently tracking effect */
+        this._activeEffect = null;
+
+        /** @type {Set<EffectHandle>} Effects queued for the current microtask */
+        this._effectQueue = new Set();
+
+        /** @type {boolean} Whether a microtask flush is scheduled */
+        this._effectScheduled = false;
+
+        /**
+         * Global symbol subscriptions: symbolName -> Set<EffectHandle>
+         * When setSymbol writes a global, all effects in the set are queued.
+         * @type {Map<string, Set<EffectHandle>>}
+         */
+        this._globalSubscriptions = new Map();
+
+        /** @type {number} Counter for assigning stable IDs to elements */
+        this._elementIdCounter = 0;
+    }
+
+    /**
+     * @param {Element} elt
+     * @returns {string}
+     */
+    _getElementId(elt) {
+        var internalData = this.runtime.getInternalData(elt);
+        if (!internalData.reactiveId) {
+            internalData.reactiveId = String(++this._elementIdCounter);
+        }
+        return internalData.reactiveId;
+    }
+
+    /**
+     * @param {string} key
+     * @param {DepRecord} record
+     */
+    _trackDep(key, record) {
+        this._activeEffect.deps.set(key, record);
+    }
+
+    /**
+     * @param {string} name
+     * @param {string} scope
+     * @param {Context} context
+     */
+    _trackSymbol(name, scope, context) {
+        if (scope === "global") {
+            this._trackDep("symbol:global:" + name,
+                { type: "symbol", name: name, scope: "global" });
+        } else if (scope === "element" && context.meta && context.meta.owner) {
+            var elt = context.meta.owner;
+            var eltId = this._getElementId(elt);
+            this._trackDep("symbol:element:" + name + ":" + eltId,
+                { type: "symbol", name: name, scope: "element", element: elt });
+        }
+    }
+
+    /**
+     * Track an element-level dependency (property or attribute).
+     * Deduplicates via the deps Map key.
+     * @param {string} trackingType - "property" or "attribute"
+     * @param {Element} element - Target element
+     * @param {string} name - Property/attribute name
+     */
+    _trackElementDep(trackingType, element, name) {
+        var key = trackingType + ":" + name + ":" + this._getElementId(element);
+        this._trackDep(key, { type: trackingType, element: element, name: name });
+    }
+
+    /**
+     * @param {string} name
+     * @param {string} scope
+     * @param {Context} context
+     */
+    _notifySymbolSubscribers(name, scope, context) {
+        if (scope === "global") {
+            var subs = this._globalSubscriptions.get(name);
+            if (subs) {
+                for (var effect of subs) {
+                    this._queueEffect(effect);
+                }
+            }
+        } else if (scope === "element" && context.meta && context.meta.owner) {
+            var elt = context.meta.owner;
+            var internalData = this.runtime.getInternalData(elt);
+            if (internalData.reactiveSubscriptions) {
+                var subs = internalData.reactiveSubscriptions.get(name);
+                if (subs) {
+                    for (var effect of subs) {
+                        this._queueEffect(effect);
+                    }
+                }
+            }
+        }
+    }
+
+    /** @param {EffectHandle} effect */
+    _queueEffect(effect) {
+        if (effect.disposed) return;
+        this._effectQueue.add(effect);
+        if (!this._effectScheduled) {
+            this._effectScheduled = true;
+            var self = this;
+            queueMicrotask(function () { self._flushEffects(); });
+        }
+    }
+
+    /** Flush all queued effects. */
+    _flushEffects() {
+        this._effectScheduled = false;
+        // Copy the queue - effects may re-queue themselves
+        var effects = Array.from(this._effectQueue);
+        this._effectQueue.clear();
+        for (var effect of effects) {
+            if (effect.disposed) continue;
+            // Auto-dispose if owning element is disconnected
+            if (effect.element && !effect.element.isConnected) {
+                this.disposeEffect(effect);
+                continue;
+            }
+            // Circular dependency guard: count accumulates across microtask
+            // flushes so cross-microtask ping-pong (effect writes to own dep)
+            // is caught. Reset happens below when the cascade settles.
+            effect._triggerCount++;
+            if (effect._triggerCount > 100) {
+                console.warn("Reactive effect triggered >100 times, stopping:", effect);
+                continue;
+            }
+            this._runEffect(effect);
+        }
+        // Reset trigger counts when the cascade settles (no more pending
+        // effects). Legitimate re-triggers on future user events start
+        // fresh, while infinite cross-microtask loops accumulate to 100.
+        if (this._effectQueue.size === 0) {
+            for (var i = 0; i < effects.length; i++) {
+                if (!effects[i].disposed) effects[i]._triggerCount = 0;
+            }
+        }
+    }
+
+    /** @param {EffectHandle} effect */
+    _runEffect(effect) {
+        // Unsubscribe from current deps
+        this._unsubscribeEffect(effect);
+
+        // Re-run compute with tracking
+        var oldDeps = effect.deps;
+        effect.deps = new Map();
+
+        var prev = this._activeEffect;
+        this._activeEffect = effect;
+        var newValue;
+        try {
+            newValue = effect.computeFn();
+        } catch (e) {
+            console.error("Error in reactive compute:", e);
+            // Restore old deps on error
+            effect.deps = oldDeps;
+            this._activeEffect = prev;
+            this._subscribeEffect(effect);
+            return;
+        }
+        this._activeEffect = prev;
+
+        // Subscribe to new deps
+        this._subscribeEffect(effect);
+
+        // Compare and fire
+        if (newValue !== effect.oldValue) {
+            effect.oldValue = newValue;
+            try {
+                effect.effectFn(newValue);
+            } catch (e) {
+                console.error("Error in reactive effect:", e);
+            }
+        }
+    }
+
+    /**
+     * Subscribe an effect to all its current deps.
+     * Symbols go into subscription maps, attributes get MutationObservers,
+     * properties use persistent per-element input/change listeners.
+     * @param {EffectHandle} effect
+     */
+    _subscribeEffect(effect) {
+        var reactivity = this;
+
+        // Iterate the unified deps Map - each value carries structured data
+        for (var [depKey, dep] of effect.deps) {
+            if (dep.type === "symbol" && dep.scope === "global") {
+                if (!this._globalSubscriptions.has(dep.name)) {
+                    this._globalSubscriptions.set(dep.name, new Set());
+                }
+                this._globalSubscriptions.get(dep.name).add(effect);
+
+            } else if (dep.type === "symbol" && dep.scope === "element") {
+                var internalData = this.runtime.getInternalData(dep.element);
+                if (!internalData.reactiveSubscriptions) {
+                    internalData.reactiveSubscriptions = new Map();
+                }
+                if (!internalData.reactiveSubscriptions.has(dep.name)) {
+                    internalData.reactiveSubscriptions.set(dep.name, new Set());
+                }
+                internalData.reactiveSubscriptions.get(dep.name).add(effect);
+
+            } else if (dep.type === "attribute") {
+                // MutationObserver for attribute changes
+                var observer = new MutationObserver(function () {
+                    reactivity._queueEffect(effect);
+                });
+                observer.observe(dep.element, {
+                    attributes: true,
+                    attributeFilter: [dep.name]
+                });
+                effect.subscriptions.push(function () {
+                    observer.disconnect();
+                });
+
+            } else if (dep.type === "property") {
+                reactivity._subscribePropertyDep(dep.element, dep.name, effect);
+            }
+        }
+    }
+
+    /**
+     * Subscribe to a DOM element property. Sets up persistent per-element
+     * event listeners and defineProperty interception. Extracted into its
+     * own method to create proper closure scope for each element/property.
+     * @param {Element} el
+     * @param {string} propName
+     * @param {EffectHandle} effect
+     */
+    _subscribePropertyDep(el, propName, effect) {
+        var reactivity = this;
+        var elData = this.runtime.getInternalData(el);
+
+        // Persistent per-element handler: set up once, shared by all
+        // effects on this element. Survives re-tracking to avoid
+        // adding/removing listeners while the browser is still
+        // dispatching the event that triggered the re-track.
+        if (!elData.reactivePropertyHandler) {
+            var trackedEffects = new Set();
+            var queueAll = function () {
+                for (var eff of trackedEffects) {
+                    reactivity._queueEffect(eff);
+                }
+            };
+
+            // Event listeners catch user interactions (typing, spinners,
+            // selects, checkboxes). Set dedup prevents double-processing
+            // when both input and change fire for the same interaction.
+            el.addEventListener("input", queueAll);
+            el.addEventListener("change", queueAll);
+
+            elData.reactivePropertyHandler = {
+                effects: trackedEffects,
+                queueAll: queueAll,
+                intercepted: {},
+                remove: function () {
+                    el.removeEventListener("input", queueAll);
+                    el.removeEventListener("change", queueAll);
+                }
+            };
+        }
+        elData.reactivePropertyHandler.effects.add(effect);
+
+        // defineProperty interception catches programmatic el.value = x
+        // assignments (no event fires for those). Persistent per property.
+        var handler = elData.reactivePropertyHandler;
+        if (!handler.intercepted[propName]) {
+            var desc =
+                Object.getOwnPropertyDescriptor(el, propName) ||
+                Object.getOwnPropertyDescriptor(Object.getPrototypeOf(el), propName);
+            if (desc && (desc.set || desc.writable !== false)) {
+                var origGet = desc.get;
+                var origSet = desc.set;
+                var storedValue = desc.value;
+                var notify = handler.queueAll;
+                Object.defineProperty(el, propName, {
+                    get: function () {
+                        return origGet ? origGet.call(this) : storedValue;
+                    },
+                    set: function (v) {
+                        if (origSet) origSet.call(this, v);
+                        else storedValue = v;
+                        notify();
+                    },
+                    enumerable: desc.enumerable !== false,
+                    configurable: true
+                });
+                handler.intercepted[propName] = desc;
+            }
+        }
+    }
+
+    /** @param {EffectHandle} effect */
+    _unsubscribeEffect(effect) {
+        // Remove from symbol subscriptions (global and element-scoped)
+        for (var [depKey, dep] of effect.deps) {
+            if (dep.type === "symbol" && dep.scope === "global") {
+                var subs = this._globalSubscriptions.get(dep.name);
+                if (subs) {
+                    subs.delete(effect);
+                    if (subs.size === 0) {
+                        this._globalSubscriptions.delete(dep.name);
+                    }
+                }
+            } else if (dep.type === "symbol" && dep.scope === "element") {
+                var internalData = this.runtime.getInternalData(dep.element);
+                if (internalData.reactiveSubscriptions) {
+                    var subs = internalData.reactiveSubscriptions.get(dep.name);
+                    if (subs) {
+                        subs.delete(effect);
+                        if (subs.size === 0) {
+                            internalData.reactiveSubscriptions.delete(dep.name);
+                        }
+                    }
+                }
+            } else if (dep.type === "property" && dep.element) {
+                var elData = this.runtime.getInternalData(dep.element);
+                if (elData.reactivePropertyHandler) {
+                    elData.reactivePropertyHandler.effects.delete(effect);
+                }
+            }
+        }
+        // Run teardown functions (MutationObservers only — property listeners are persistent)
+        for (var teardown of effect.subscriptions) {
+            try { teardown(); } catch (e) { /* ignore cleanup errors */ }
+        }
+        effect.subscriptions = [];
+    }
+
+    /**
+     * Create a reactive effect with automatic dependency tracking.
+     * computeFn is evaluated while recording reads. When any tracked
+     * dependency changes, computeFn re-evaluates and effectFn fires
+     * if the result changed (===).
+     *
+     * @param {() => any} computeFn
+     * @param {(newValue: any) => void} effectFn
+     * @param {Object} [options]
+     * @param {Element} [options.element] - auto-dispose on disconnect
+     * @returns {() => void} dispose function
+     */
+    createEffect(computeFn, effectFn, options) {
+        var effect = {
+            computeFn: computeFn,
+            effectFn: effectFn,
+            deps: new Map(),
+            oldValue: undefined,
+            element: (options && options.element) || null,
+            disposed: false,
+            subscriptions: [],
+            _triggerCount: 0,
+        };
+
+        // Initial tracked evaluation
+        var prev = this._activeEffect;
+        this._activeEffect = effect;
+        try {
+            effect.oldValue = computeFn();
+        } catch (e) {
+            console.error("Error in reactive compute:", e);
+        }
+        this._activeEffect = prev;
+
+        // Subscribe to tracked deps
+        this._subscribeEffect(effect);
+
+        // Initial sync: if value already exists, fire effectFn immediately
+        if (effect.oldValue !== undefined) {
+            try {
+                effectFn(effect.oldValue);
+            } catch (e) {
+                console.error("Error in reactive effect:", e);
+            }
+        }
+
+        var reactivity = this;
+        return function dispose() {
+            reactivity.disposeEffect(effect);
+        };
+    }
+
+    /** @param {EffectHandle} effect */
+    disposeEffect(effect) {
+        if (effect.disposed) return;
+        effect.disposed = true;
+        this._unsubscribeEffect(effect);
+        // Clean up per-element listeners and interceptions if no effects remain
+        for (var [depKey, dep] of effect.deps) {
+            if (dep.type === "property" && dep.element) {
+                var elData = this.runtime.getInternalData(dep.element);
+                var handler = elData.reactivePropertyHandler;
+                if (handler && handler.effects.size === 0) {
+                    handler.remove();
+                    // Restore original property descriptors
+                    for (var prop in handler.intercepted) {
+                        Object.defineProperty(dep.element, prop, handler.intercepted[prop]);
+                    }
+                    delete elData.reactivePropertyHandler;
+                }
+            }
+        }
+        this._effectQueue.delete(effect);
+    }
+}

--- a/src/core/runtime.js
+++ b/src/core/runtime.js
@@ -1,6 +1,7 @@
 // Runtime - Execution engine for _hyperscript
 import { config, conversions } from './config.js';
 import { Tokens } from './tokenizer.js';
+import { Reactivity } from './reactivity.js';
 
 // ============================================================================
 // Utility classes and symbols (from util.js)
@@ -303,6 +304,12 @@ export function varargConstructor(Cls, args) {
 // Runtime class
 // ============================================================================
 
+/** Hoisted getter for resolveProperty - avoids allocating a closure per call */
+const PROP_GETTER = (root, property) => root[property];
+
+/** Hoisted getter for resolveAttribute - avoids allocating a closure per call */
+const ATTR_GETTER = (root, property) => root.getAttribute && root.getAttribute(property);
+
 export class Runtime {
         /**
          *
@@ -317,6 +324,9 @@ export class Runtime {
 
             // Initialize web-specific conversions
             this.initWebConversions();
+
+            /** @type {Reactivity} Reactive effect system */
+            this.reactivity = new Reactivity(this);
         }
 
         /**
@@ -832,8 +842,10 @@ export class Runtime {
                 return context.you;
             } else {
                 if (type === "global") {
+                    if (this.reactivity._activeEffect) this.reactivity._trackSymbol(str, "global", context);
                     return this.globalScope[str];
                 } else if (type === "element") {
+                    if (this.reactivity._activeEffect) this.reactivity._trackSymbol(str, "element", context);
                     var elementScope = this.getElementScope(context);
                     return elementScope[str];
                 } else if (type === "local") {
@@ -861,15 +873,19 @@ export class Runtime {
                         var fromContext = context[str];
                     }
                     if (typeof fromContext !== "undefined") {
+                        // Found in locals/meta - don't track (ephemeral)
                         return fromContext;
                     } else {
                         // element scope
                         var elementScope = this.getElementScope(context);
                         fromContext = elementScope[str];
                         if (typeof fromContext !== "undefined") {
+                            if (this.reactivity._activeEffect) this.reactivity._trackSymbol(str, "element", context);
                             return fromContext;
                         } else {
-                            // global scope
+                            // Global scope (or not found - track as global
+                            // so we catch the first write)
+                            if (this.reactivity._activeEffect) this.reactivity._trackSymbol(str, "global", context);
                             return this.globalScope[str];
                         }
                     }
@@ -880,14 +896,17 @@ export class Runtime {
         setSymbol(str, context, type, value) {
             if (type === "global") {
                 this.globalScope[str] = value;
+                this.reactivity._notifySymbolSubscribers(str, "global", context);
             } else if (type === "element") {
                 var elementScope = this.getElementScope(context);
                 elementScope[str] = value;
+                this.reactivity._notifySymbolSubscribers(str, "element", context);
             } else if (type === "local") {
                 context.locals[str] = value;
+                // Don't notify - local scope is ephemeral
             } else {
                 if (this.isHyperscriptContext(context) && !this.isReservedWord(str) && typeof context.locals[str] !== "undefined") {
-                    // local scope
+                    // local scope - don't notify
                     context.locals[str] = value;
                 } else {
                     // element scope
@@ -895,9 +914,10 @@ export class Runtime {
                     var fromContext = elementScope[str];
                     if (typeof fromContext !== "undefined") {
                         elementScope[str] = value;
+                        this.reactivity._notifySymbolSubscribers(str, "element", context);
                     } else {
                         if (this.isHyperscriptContext(context) && !this.isReservedWord(str)) {
-                            // local scope
+                            // local scope - don't notify
                             context.locals[str] = value;
                         } else {
                             // direct set on normal JS object or top-level of context
@@ -906,6 +926,14 @@ export class Runtime {
                     }
                 }
             }
+        }
+
+        createEffect(computeFn, effectFn, options) {
+            return this.reactivity.createEffect(computeFn, effectFn, options);
+        }
+
+        disposeEffect(effect) {
+            return this.reactivity.disposeEffect(effect);
         }
 
         /**
@@ -935,8 +963,13 @@ export class Runtime {
         * @param {Object<string,any>} root
         * @param {string} property
         */
-        flatGet(root, property, getter) {
+        flatGet(root, property, getter, trackingType) {
             if (root != null) {
+                // Track the read if an effect is active
+                if (this.reactivity._activeEffect && trackingType && root instanceof Element) {
+                    this.reactivity._trackElementDep(trackingType, root, property);
+                }
+
                 var val = getter(root, property);
                 if (typeof val !== "undefined") {
                     return val;
@@ -946,6 +979,10 @@ export class Runtime {
                     // flat map
                     var result = [];
                     for (var component of root) {
+                        // Track each element in the collection
+                        if (this.reactivity._activeEffect && trackingType && component instanceof Element) {
+                            this.reactivity._trackElementDep(trackingType, component, property);
+                        }
                         var componentValue = getter(component, property);
                         result.push(componentValue);
                     }
@@ -955,11 +992,11 @@ export class Runtime {
         }
 
         resolveProperty(root, property) {
-            return this.flatGet(root, property, (root, property) => root[property] )
+            return this.flatGet(root, property, PROP_GETTER, "property")
         }
 
         resolveAttribute(root, property) {
-            return this.flatGet(root, property, (root, property) => root.getAttribute && root.getAttribute(property) )
+            return this.flatGet(root, property, ATTR_GETTER, "attribute")
         }
 
         /**

--- a/src/parsetree/expressions/webliterals.js
+++ b/src/parsetree/expressions/webliterals.js
@@ -211,7 +211,7 @@ class AttributeRefNode extends Expression {
     resolve(context) {
         var target = context.you || context.me;
         if (target) {
-            return target.getAttribute(this.name);
+            return context.meta.runtime.resolveAttribute(target, this.name);
         }
     }
 }

--- a/src/parsetree/features/bind.js
+++ b/src/parsetree/features/bind.js
@@ -1,0 +1,168 @@
+/**
+ * Bind Feature - Reactive binding (sugar over `when ... changes`)
+ *
+ * Two forms:
+ *
+ *   bind <target> to <expression>
+ *     One-way (computed/derived). Target always reflects the expression's
+ *     value. Equivalent to:
+ *       when <expression> changes
+ *           set <target> to it
+ *
+ *   bind <target> and <target>
+ *     Two-way. Both sides stay in sync. Changes to either propagate to
+ *     the other. Equivalent to:
+ *       when <left> changes
+ *           set <right> to it
+ *       end
+ *       when <right> changes
+ *           set <left> to it
+ *
+ * Supports the same targets as `set`: variables ($foo, :bar),
+ * attributes (@data-x), properties (my.value), etc.
+ */
+
+import { Feature } from '../base.js';
+
+export class BindFeature extends Feature {
+    static keyword = "bind";
+
+    /**
+     * Parse bind feature
+     * @param {Parser} parser
+     * @returns {BindFeature | undefined}
+     */
+    static parse(parser) {
+        if (!parser.matchToken("bind")) return;
+
+        // Parse the left-hand side. pushFollow prevents "to" and "and"
+        // from being consumed as part of the expression.
+        parser.pushFollow("to");
+        parser.pushFollow("and");
+        var left;
+        try {
+            left = parser.requireElement("expression");
+        } finally {
+            parser.popFollow();
+            parser.popFollow();
+        }
+
+        var mode;
+        if (parser.matchToken("to")) {
+            mode = "to";
+        } else if (parser.matchToken("and")) {
+            mode = "and";
+        } else {
+            parser.raiseParseError("Expected 'to' or 'and' after bind expression");
+        }
+
+        var right = parser.requireElement("expression");
+
+        return new BindFeature(left, right, mode);
+    }
+
+    constructor(left, right, mode) {
+        super();
+        this.left = left;
+        this.right = right;
+        this.mode = mode;
+        this.displayName = "bind ... " + mode + " ...";
+    }
+
+    install(target, source, args, runtime) {
+        var feature = this;
+        queueMicrotask(function () {
+            if (feature.mode === "to") {
+                // One-way: right expression drives left target
+                runtime.createEffect(
+                    function () {
+                        return feature.right.evaluate(
+                            runtime.makeContext(target, feature, target, null)
+                        );
+                    },
+                    function (newValue) {
+                        var ctx = runtime.makeContext(target, feature, target, null);
+                        _assignTo(runtime, feature.left, ctx, newValue);
+                    },
+                    { element: target }
+                );
+            } else {
+                // Two-way: left ↔ right
+                // Effect 1: left changes → set right
+                runtime.createEffect(
+                    function () {
+                        return feature.left.evaluate(
+                            runtime.makeContext(target, feature, target, null)
+                        );
+                    },
+                    function (newValue) {
+                        var ctx = runtime.makeContext(target, feature, target, null);
+                        _assignTo(runtime, feature.right, ctx, newValue);
+                    },
+                    { element: target }
+                );
+                // Effect 2: right changes → set left
+                runtime.createEffect(
+                    function () {
+                        return feature.right.evaluate(
+                            runtime.makeContext(target, feature, target, null)
+                        );
+                    },
+                    function (newValue) {
+                        var ctx = runtime.makeContext(target, feature, target, null);
+                        _assignTo(runtime, feature.left, ctx, newValue);
+                    },
+                    { element: target }
+                );
+            }
+        });
+    }
+}
+
+/**
+ * Assign a value to a parsed expression target, mirroring what
+ * the `set` command does for each target type.
+ * @param {Runtime} runtime
+ * @param {ASTNode} target - The parsed expression to assign to
+ * @param {Context} ctx - Execution context
+ * @param {any} value - Value to assign
+ */
+function _assignTo(runtime, target, ctx, value) {
+    if (target.type === "symbol") {
+        runtime.setSymbol(target.name, ctx, target.scope, value);
+    } else if (target.type === "attributeRef") {
+        var elt = ctx.you || ctx.me;
+        if (elt) {
+            if (value == null) {
+                elt.removeAttribute(target.name);
+            } else {
+                elt.setAttribute(target.name, value);
+            }
+        }
+    } else if (target.type === "propertyAccess" || target.type === "possessive") {
+        var root = target.root ? target.root.evaluate(ctx) : ctx.me;
+        var prop = target.prop ? target.prop.value : target.name;
+        if (root != null) {
+            runtime.implicitLoop(root, function (elt) {
+                elt[prop] = value;
+            });
+        }
+    } else if (target.type === "attributeRefAccess") {
+        var root = target.root ? target.root.evaluate(ctx) : ctx.me;
+        var attr = target.attribute ? target.attribute.name : target.name;
+        if (root != null) {
+            runtime.implicitLoop(root, function (elt) {
+                if (value == null) {
+                    elt.removeAttribute(attr);
+                } else {
+                    elt.setAttribute(attr, value);
+                }
+            });
+        }
+    } else if (target.type === "styleRef") {
+        var elt = ctx.you || ctx.me;
+        if (elt) {
+            elt.style[target.name] = value;
+        }
+    }
+}

--- a/src/parsetree/features/when.js
+++ b/src/parsetree/features/when.js
@@ -1,0 +1,82 @@
+/**
+ * When Feature - Reactive effect
+ *
+ * Parses: when <expression> [or <expression>]* changes <commands>
+ * Executes: Re-runs commands when the watched expression's value changes.
+ *           Dependencies are tracked automatically via createEffect.
+ */
+
+import { Feature } from '../base.js';
+
+export class WhenFeature extends Feature {
+    static keyword = "when";
+
+    /**
+     * Parse when feature
+     * @param {Parser} parser
+     * @returns {WhenFeature | undefined}
+     */
+    static parse(parser) {
+        if (!parser.matchToken("when")) return;
+
+        // Collect one or more watched expressions, separated by "or".
+        // pushFollow("or") tells the expression parser to stop before "or"
+        // instead of consuming it as a logical operator.
+        var exprs = [];
+        do {
+            parser.pushFollow("or");
+            try {
+                exprs.push(parser.requireElement("expression"));
+            } finally {
+                parser.popFollow();
+            }
+        } while (parser.matchToken("or"));
+
+        parser.requireToken("changes");
+        var start = parser.requireElement("commandList");
+        parser.ensureTerminated(start);
+        var feature = new WhenFeature(exprs, start);
+        parser.setParent(start, feature);
+        return feature;
+    }
+
+    constructor(exprs, start) {
+        super();
+        this.exprs = exprs;
+        this.start = start;
+        this.displayName = "when ... changes";
+    }
+
+    install(target, source, args, runtime) {
+        var feature = this;
+        // Defer effect creation to a microtask so that ID references (e.g.
+        // #reactive-input) can be resolved after the element is appended to
+        // the DOM.
+        queueMicrotask(function () {
+            // Create one effect per watched expression. Each triggers the
+            // same command list, mirroring how `on` handles `or` for events.
+            for (var i = 0; i < feature.exprs.length; i++) {
+                (function (expr) {
+                    runtime.createEffect(
+                        function () {
+                            return expr.evaluate(
+                                runtime.makeContext(target, feature, target, null)
+                            );
+                        },
+                        function (newValue) {
+                            var ctx = runtime.makeContext(target, feature, target, null);
+                            ctx.result = newValue;
+                            ctx.meta.reject = function (err) {
+                                console.error(err.message ? err.message : err);
+                                runtime.triggerEvent(target, "exception", { error: err });
+                            };
+                            ctx.meta.onHalt = function () {};
+                            feature.start.execute(ctx);
+                        },
+                        { element: target }
+                    );
+                })(feature.exprs[i]);
+            }
+        });
+    }
+}

--- a/test/features/bind.js
+++ b/test/features/bind.js
@@ -1,0 +1,223 @@
+describe("the bind feature", function () {
+    beforeEach(function () {
+        clearWorkArea();
+    });
+    afterEach(function () {
+        clearWorkArea();
+    });
+
+    function tick(ms) {
+        return new Promise(function (resolve) { setTimeout(resolve, ms || 20); });
+    }
+
+    // === One-way binding (bind X to Y) ===
+
+    it("bind X to Y is sugar for when Y changes set X to it", async function () {
+        _hyperscript.evaluate("set $firstName to 'John'");
+        _hyperscript.evaluate("set $lastName to 'Doe'");
+
+        var div = make(
+            `<div _="bind :fullName to ($firstName + ' ' + $lastName)
+                     when :fullName changes
+                         put it into me"></div>`
+        );
+
+        await tick();
+        div.innerHTML.should.equal("John Doe");
+
+        _hyperscript.evaluate("set $firstName to 'Jane'");
+        await tick();
+        div.innerHTML.should.equal("Jane Doe");
+
+        delete window.$firstName;
+        delete window.$lastName;
+    });
+
+    it("bind variable to attribute", async function () {
+        var div = make(
+            `<div data-color="red"
+                  _="bind $color to @data-color
+                     when $color changes
+                         put it into me"></div>`
+        );
+
+        await tick();
+        div.innerHTML.should.equal("red");
+
+        div.setAttribute("data-color", "blue");
+        await tick(50);
+        div.innerHTML.should.equal("blue");
+
+        delete window.$color;
+    });
+
+    it("bind attribute to variable", async function () {
+        _hyperscript.evaluate("set $title to 'hello'");
+
+        var div = make(
+            `<div _="bind @data-title to $title"></div>`
+        );
+
+        await tick();
+        div.getAttribute("data-title").should.equal("hello");
+
+        _hyperscript.evaluate("set $title to 'updated'");
+        await tick();
+        div.getAttribute("data-title").should.equal("updated");
+
+        delete window.$title;
+    });
+
+    // === Two-way binding (bind X and Y) ===
+
+    it("bind variable and input value (two-way)", async function () {
+        var container = make(
+            `<div>
+                 <input type="text" id="bind-input" value="initial" />
+                 <span id="bind-output"
+                       _="bind $username and #bind-input.value
+                          when $username changes
+                              put it into me"></span>
+             </div>`
+        );
+        var input = document.getElementById("bind-input");
+        var span = document.getElementById("bind-output");
+
+        await tick();
+        // Initial sync: input value → $username → span
+        span.innerHTML.should.equal("initial");
+
+        // User types in input → $username updates → span updates
+        input.value = "typed";
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+        await tick(50);
+        span.innerHTML.should.equal("typed");
+
+        // Programmatic variable change → input updates
+        _hyperscript.evaluate("set $username to 'programmatic'");
+        await tick();
+        input.value.should.equal("programmatic");
+
+        delete window.$username;
+    });
+
+    it("bind variable and attribute (two-way)", async function () {
+        _hyperscript.evaluate("set $theme to 'light'");
+
+        var div = make(
+            `<div _="bind $theme and @data-theme"></div>`
+        );
+
+        await tick();
+        div.getAttribute("data-theme").should.equal("light");
+
+        _hyperscript.evaluate("set $theme to 'dark'");
+        await tick();
+        div.getAttribute("data-theme").should.equal("dark");
+
+        div.setAttribute("data-theme", "auto");
+        await tick(50);
+        window.$theme.should.equal("auto");
+
+        delete window.$theme;
+    });
+
+    it("bind checkbox checked state and variable (two-way)", async function () {
+        var container = make(
+            `<div>
+                 <input type="checkbox" id="bind-check" />
+                 <span _="bind $enabled and #bind-check.checked
+                          when $enabled changes
+                              if it is true
+                                  put 'ON' into me
+                              else
+                                  put 'OFF' into me
+                              end"></span>
+             </div>`
+        );
+        var checkbox = document.getElementById("bind-check");
+        var span = container.querySelector("span");
+
+        await tick();
+        span.innerHTML.should.equal("OFF");
+
+        // User checks the box
+        checkbox.checked = true;
+        checkbox.dispatchEvent(new Event("change", { bubbles: true }));
+        await tick(50);
+        span.innerHTML.should.equal("ON");
+
+        // Programmatic uncheck via variable
+        _hyperscript.evaluate("set $enabled to false");
+        await tick();
+        checkbox.checked.should.be.false;
+        span.innerHTML.should.equal("OFF");
+
+        delete window.$enabled;
+    });
+
+    // === Edge cases ===
+
+    it("bind does not infinite loop with two-way (dedup prevents it)", async function () {
+        _hyperscript.evaluate("set $stable to 'start'");
+
+        var div = make(
+            `<div _="bind $stable and @data-val"></div>`
+        );
+
+        await tick();
+        div.getAttribute("data-val").should.equal("start");
+
+        _hyperscript.evaluate("set $stable to 'changed'");
+        await tick(50);
+        div.getAttribute("data-val").should.equal("changed");
+
+        // Should not have infinite-looped — dedup catches it
+        window.$stable.should.equal("changed");
+    });
+
+    it("multiple bind features on same element", async function () {
+        _hyperscript.evaluate("set $x to 'X'");
+        _hyperscript.evaluate("set $y to 'Y'");
+
+        var div = make(
+            `<div _="bind @data-x to $x
+                     bind @data-y to $y"></div>`
+        );
+
+        await tick();
+        div.getAttribute("data-x").should.equal("X");
+        div.getAttribute("data-y").should.equal("Y");
+
+        _hyperscript.evaluate("set $x to 'newX'");
+        await tick();
+        div.getAttribute("data-x").should.equal("newX");
+        div.getAttribute("data-y").should.equal("Y");
+
+        delete window.$x;
+        delete window.$y;
+    });
+
+    it("bind my textContent to a computed expression", async function () {
+        _hyperscript.evaluate("set $price to 10");
+        _hyperscript.evaluate("set $qty to 3");
+
+        var div = make(
+            `<div _="bind my textContent to '$' + ($price * $qty)"></div>`
+        );
+
+        await tick();
+        div.textContent.should.equal("$30");
+
+        _hyperscript.evaluate("set $price to 25");
+        await tick();
+        div.textContent.should.equal("$75");
+
+        _hyperscript.evaluate("set $qty to 2");
+        await tick();
+        div.textContent.should.equal("$50");
+
+        delete window.$price;
+        delete window.$qty;
+    });
+});

--- a/test/features/when.js
+++ b/test/features/when.js
@@ -1,0 +1,680 @@
+describe("the when feature", function () {
+    beforeEach(function () {
+        clearWorkArea();
+    });
+    afterEach(function () {
+        clearWorkArea();
+    });
+
+    // Yield to microtask queue (effects batch via queueMicrotask)
+    function tick(ms) {
+        return new Promise(function (resolve) { setTimeout(resolve, ms || 20); });
+    }
+
+    // === Core behavior (ported from feature/when branch) ===
+
+    it("provides access to `it` and syncs initial value", async function () {
+        _hyperscript.evaluate("set $global to 'initial'");
+
+        var div = make(
+            `<div _="when $global changes
+                         put it into me"></div>`
+        );
+
+        await tick();
+        div.innerHTML.should.equal("initial");
+
+        _hyperscript.evaluate("set $global to 'hello world'");
+        await tick();
+        div.innerHTML.should.equal("hello world");
+
+        _hyperscript.evaluate("set $global to 42");
+        await tick();
+        div.innerHTML.should.equal("42");
+
+        delete window.$global;
+    });
+
+    it("detects changes from $global variable", async function () {
+        var div = make(
+            `<div _="when $global changes
+                         put it into me"></div>`
+        );
+
+        _hyperscript.evaluate("set $global to 'Changed!'");
+        await tick();
+        div.innerHTML.should.equal("Changed!");
+
+        delete window.$global;
+    });
+
+    it("detects changes from :element variable", async function () {
+        var div = make(
+            `<div _="init set :count to 0 end
+                     when :count changes
+                         put it into me
+                     end
+                     on click increment :count">0</div>`
+        );
+
+        await tick();
+        div.innerHTML.should.equal("0");
+
+        div.click();
+        await tick();
+        div.innerHTML.should.equal("1");
+
+        div.click();
+        await tick();
+        div.innerHTML.should.equal("2");
+    });
+
+    it("triggers multiple elements watching same variable", async function () {
+        var div1 = make(
+            `<div _="when $shared changes
+                         put 'first' into me"></div>`
+        );
+        var div2 = make(
+            `<div _="when $shared changes
+                         put 'second' into me"></div>`
+        );
+
+        _hyperscript.evaluate("set $shared to 'changed'");
+        await tick();
+
+        div1.innerHTML.should.equal("first");
+        div2.innerHTML.should.equal("second");
+
+        delete window.$shared;
+    });
+
+    it("executes multiple commands", async function () {
+        var div = make(
+            `<div _="when $multi changes
+                         put 'first' into me
+                         add .executed to me"></div>`
+        );
+
+        _hyperscript.evaluate("set $multi to 'go'");
+        await tick();
+
+        div.innerHTML.should.equal("first");
+        div.classList.contains("executed").should.be.true;
+
+        delete window.$multi;
+    });
+
+    it("does not execute when variable is undefined initially", async function () {
+        var div = make(
+            `<div _="when $neverSet changes
+                         put 'synced' into me">original</div>`
+        );
+
+        await tick(50);
+        div.innerHTML.should.equal("original");
+    });
+
+    it("only triggers when variable actually changes value", async function () {
+        var div = make(
+            `<div _="when $dedup changes
+                         increment :callCount
+                         put :callCount into me"></div>`
+        );
+
+        _hyperscript.evaluate("set $dedup to 'value1'");
+        await tick();
+        div.innerHTML.should.equal("1");
+
+        _hyperscript.evaluate("set $dedup to 'value1'");
+        await tick();
+        div.innerHTML.should.equal("1");
+
+        _hyperscript.evaluate("set $dedup to 'value2'");
+        await tick();
+        div.innerHTML.should.equal("2");
+
+        delete window.$dedup;
+    });
+
+    // === Auto-tracking ===
+
+    it("auto-tracks compound expressions", async function () {
+        _hyperscript.evaluate("set $a to 1");
+        _hyperscript.evaluate("set $b to 2");
+
+        var div = make(
+            `<div _="when ($a + $b) changes
+                         put it into me"></div>`
+        );
+
+        await tick();
+        div.innerHTML.should.equal("3");
+
+        _hyperscript.evaluate("set $a to 10");
+        await tick();
+        div.innerHTML.should.equal("12");
+
+        _hyperscript.evaluate("set $b to 20");
+        await tick();
+        div.innerHTML.should.equal("30");
+
+        delete window.$a;
+        delete window.$b;
+    });
+
+    // === Attribute & property tracking ===
+
+    it("detects attribute changes", async function () {
+        var div = make(
+            `<div data-title="original"
+                  _="when @data-title changes
+                         put it into me"></div>`
+        );
+
+        await tick();
+        div.innerHTML.should.equal("original");
+
+        div.setAttribute("data-title", "updated");
+        await tick(50);
+        div.innerHTML.should.equal("updated");
+    });
+
+    it("detects form input value changes via user interaction", async function () {
+        var container = make(
+            `<div>
+                 <input type="text" id="reactive-input" value="start" />
+                 <span _="when #reactive-input.value changes
+                               put it into me"></span>
+             </div>`
+        );
+        var input = document.getElementById("reactive-input");
+        var span = container.querySelector("span");
+
+        await tick();
+        span.innerHTML.should.equal("start");
+
+        input.value = "typed";
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+        await tick(50);
+        span.innerHTML.should.equal("typed");
+    });
+
+    it("detects programmatic .value = without event dispatch", async function () {
+        var container = make(
+            `<div>
+                 <input type="text" id="prog-input" value="initial" />
+                 <span _="when #prog-input.value changes
+                               put it into me"></span>
+             </div>`
+        );
+        var input = document.getElementById("prog-input");
+        var span = container.querySelector("span");
+
+        await tick();
+        span.innerHTML.should.equal("initial");
+
+        // Set value programmatically — no event dispatched
+        input.value = "programmatic";
+        await tick(50);
+        span.innerHTML.should.equal("programmatic");
+    });
+
+    // === Lifecycle ===
+
+    it("disposes effect when element is removed from DOM", async function () {
+        _hyperscript.evaluate("set $dispose to 'before'");
+
+        var div = make(
+            `<div _="when $dispose changes
+                         put it into me"></div>`
+        );
+
+        await tick();
+        div.innerHTML.should.equal("before");
+
+        div.parentNode.removeChild(div);
+
+        _hyperscript.evaluate("set $dispose to 'after'");
+        await tick(50);
+        div.innerHTML.should.equal("before");
+
+        delete window.$dispose;
+    });
+
+    // === Edge cases ===
+
+    it("batches multiple synchronous writes into one effect run", async function () {
+        _hyperscript.evaluate("set $batchA to 0");
+        _hyperscript.evaluate("set $batchB to 0");
+
+        var div = make(
+            `<div _="when ($batchA + $batchB) changes
+                         increment :runCount
+                         put :runCount into me"></div>`
+        );
+
+        await tick();
+        div.innerHTML.should.equal("1");
+
+        _hyperscript.evaluate("set $batchA to 5");
+        _hyperscript.evaluate("set $batchB to 10");
+        await tick();
+        div.innerHTML.should.equal("2");
+
+        delete window.$batchA;
+        delete window.$batchB;
+    });
+
+    it("handles chained reactivity across elements", async function () {
+        make(
+            `<div _="when $source changes
+                         set $derived to (it * 2)"></div>`
+        );
+        var output = make(
+            `<div _="when $derived changes
+                         put it into me"></div>`
+        );
+
+        _hyperscript.evaluate("set $source to 5");
+        await tick();
+        await tick();
+
+        output.innerHTML.should.equal("10");
+
+        _hyperscript.evaluate("set $source to 20");
+        await tick();
+        await tick();
+
+        output.innerHTML.should.equal("40");
+
+        delete window.$source;
+        delete window.$derived;
+    });
+
+    it("supports multiple when features on the same element", async function () {
+        _hyperscript.evaluate("set $left to 'L'");
+        _hyperscript.evaluate("set $right to 'R'");
+
+        var div = make(
+            `<div _="when $left changes
+                         put it into my @data-left
+                     end
+                     when $right changes
+                         put it into my @data-right"></div>`
+        );
+
+        await tick();
+        div.getAttribute("data-left").should.equal("L");
+        div.getAttribute("data-right").should.equal("R");
+
+        _hyperscript.evaluate("set $left to 'newL'");
+        await tick();
+        div.getAttribute("data-left").should.equal("newL");
+        div.getAttribute("data-right").should.equal("R");
+
+        delete window.$left;
+        delete window.$right;
+    });
+
+    it("works with on handlers that modify the watched variable", async function () {
+        var div = make(
+            `<div _="init set :label to 'initial' end
+                     when :label changes
+                         put it into me
+                     end
+                     on click set :label to 'clicked'">initial</div>`
+        );
+
+        await tick();
+        div.innerHTML.should.equal("initial");
+
+        div.click();
+        await tick();
+        div.innerHTML.should.equal("clicked");
+    });
+
+    it("handles attribute changes set via hyperscript commands", async function () {
+        var div = make(
+            `<div data-status="pending"
+                  _="when @data-status changes
+                         put it into me
+                     end
+                     on click set @data-status to 'done'"></div>`
+        );
+
+        await tick();
+        div.innerHTML.should.equal("pending");
+
+        div.click();
+        await tick(50);
+        div.innerHTML.should.equal("done");
+    });
+
+    it("does not cross-trigger on unrelated variable writes", async function () {
+        var div = make(
+            `<div _="when $trigger changes
+                         increment :count
+                         put :count into me
+                         set $other to 'side-effect'"></div>`
+        );
+
+        _hyperscript.evaluate("set $trigger to 'go'");
+        await tick();
+        div.innerHTML.should.equal("1");
+
+        await tick();
+        div.innerHTML.should.equal("1");
+
+        delete window.$trigger;
+        delete window.$other;
+    });
+
+    it("handles checkbox checked state via change event", async function () {
+        var container = make(
+            `<div>
+                 <input type="checkbox" id="reactive-check" />
+                 <span _="when #reactive-check.checked changes
+                               if it is true
+                                   put 'ON' into me
+                               else
+                                   put 'OFF' into me
+                               end"></span>
+             </div>`
+        );
+        var checkbox = document.getElementById("reactive-check");
+        var span = container.querySelector("span");
+
+        await tick();
+        span.innerHTML.should.equal("OFF");
+
+        checkbox.checked = true;
+        checkbox.dispatchEvent(new Event("change", { bubbles: true }));
+        await tick(50);
+        span.innerHTML.should.equal("ON");
+
+        checkbox.checked = false;
+        checkbox.dispatchEvent(new Event("change", { bubbles: true }));
+        await tick(50);
+        span.innerHTML.should.equal("OFF");
+    });
+
+    it("handles rapid successive changes correctly", async function () {
+        var div = make(
+            `<div _="when $rapid changes
+                         put it into me"></div>`
+        );
+
+        for (var i = 0; i < 10; i++) {
+            _hyperscript.evaluate("set $rapid to " + i);
+        }
+        await tick();
+        div.innerHTML.should.equal("9");
+
+        delete window.$rapid;
+    });
+
+    it("continues working after an error in the effect body", async function () {
+        var div = make(
+            `<div _="when $robust changes
+                         put it into me"></div>`
+        );
+
+        _hyperscript.evaluate("set $robust to 'first'");
+        await tick();
+        div.innerHTML.should.equal("first");
+
+        _hyperscript.evaluate("set $robust to 'second'");
+        await tick();
+        div.innerHTML.should.equal("second");
+
+        delete window.$robust;
+    });
+
+    it("isolates element-scoped variables between elements", async function () {
+        var div1 = make(
+            `<div _="init set :value to 'A' end
+                     when :value changes
+                         put it into me
+                     end
+                     on click set :value to 'A-clicked'">A</div>`
+        );
+        var div2 = make(
+            `<div _="init set :value to 'B' end
+                     when :value changes
+                         put it into me
+                     end
+                     on click set :value to 'B-clicked'">B</div>`
+        );
+
+        await tick();
+        div1.innerHTML.should.equal("A");
+        div2.innerHTML.should.equal("B");
+
+        div1.click();
+        await tick();
+        div1.innerHTML.should.equal("A-clicked");
+        div2.innerHTML.should.equal("B");
+
+        div2.click();
+        await tick();
+        div1.innerHTML.should.equal("A-clicked");
+        div2.innerHTML.should.equal("B-clicked");
+    });
+
+    // === Multiple effects on same input (shopping cart scenario) ===
+
+    it("handles multiple effects watching the same input property", async function () {
+        this.timeout(5000);
+        var container = make(
+            `<div>
+                 <input type="number" id="sc-price" value="10" step="1" />
+                 <input type="number" id="sc-qty" value="2" />
+                 <span id="sc-sub" _="when (#sc-price.value * #sc-qty.value) changes
+                                          put '$' + it into me"></span>
+                 <span id="sc-dbl" _="when (#sc-price.value * #sc-qty.value * 2) changes
+                                          put '$' + it into me"></span>
+                 <span id="sc-tri" _="when (#sc-price.value * #sc-qty.value * 3) changes
+                                          put '$' + it into me"></span>
+             </div>`
+        );
+
+        var price = document.getElementById("sc-price");
+        var sub = document.getElementById("sc-sub");
+        var dbl = document.getElementById("sc-dbl");
+        var tri = document.getElementById("sc-tri");
+
+        await tick();
+        sub.innerHTML.should.equal("$20");
+        dbl.innerHTML.should.equal("$40");
+        tri.innerHTML.should.equal("$60");
+
+        // Simulate user changing price (fires both input and change on number inputs)
+        price.value = "15";
+        price.dispatchEvent(new Event("input", { bubbles: true }));
+        await tick(50);
+
+        sub.innerHTML.should.equal("$30");
+        dbl.innerHTML.should.equal("$60");
+        tri.innerHTML.should.equal("$90");
+
+        // Fire change event too (like number input spinner does)
+        price.dispatchEvent(new Event("change", { bubbles: true }));
+        await tick(50);
+
+        // Values should be the same — no cascade
+        sub.innerHTML.should.equal("$30");
+        dbl.innerHTML.should.equal("$60");
+        tri.innerHTML.should.equal("$90");
+    });
+
+    // === Performance & safety ===
+
+    it("handles 50 elements watching the same variable", async function () {
+        this.timeout(5000);
+        var divs = [];
+        for (var i = 0; i < 50; i++) {
+            divs.push(make(
+                `<div _="when $fan changes
+                             put it into me"></div>`
+            ));
+        }
+
+        var start = performance.now();
+        _hyperscript.evaluate("set $fan to 'broadcast'");
+        await tick();
+        var elapsed = performance.now() - start;
+
+        for (var j = 0; j < 50; j++) {
+            divs[j].innerHTML.should.equal("broadcast");
+        }
+        elapsed.should.be.below(500);
+
+        delete window.$fan;
+    });
+
+    it("handles 100 rapid writes without hanging", async function () {
+        this.timeout(5000);
+        var div = make(
+            `<div _="when $firehose changes
+                         put it into me"></div>`
+        );
+
+        var start = performance.now();
+        for (var i = 0; i < 100; i++) {
+            _hyperscript.evaluate("set $firehose to " + i);
+        }
+        await tick();
+        var elapsed = performance.now() - start;
+
+        div.innerHTML.should.equal("99");
+        elapsed.should.be.below(500);
+
+        delete window.$firehose;
+    });
+
+    it("handles a 5-element reactive chain without blowing up", async function () {
+        this.timeout(5000);
+        // $step0 → $step1 → $step2 → $step3 → $step4
+        make(`<div _="when $step0 changes set $step1 to (it + 1)"></div>`);
+        make(`<div _="when $step1 changes set $step2 to (it + 1)"></div>`);
+        make(`<div _="when $step2 changes set $step3 to (it + 1)"></div>`);
+        make(`<div _="when $step3 changes set $step4 to (it + 1)"></div>`);
+        var output = make(
+            `<div _="when $step4 changes
+                         put it into me"></div>`
+        );
+
+        var start = performance.now();
+        _hyperscript.evaluate("set $step0 to 0");
+
+        // Each link needs a microtask to propagate
+        for (var i = 0; i < 5; i++) { await tick(); }
+        var elapsed = performance.now() - start;
+
+        output.innerHTML.should.equal("4");
+        elapsed.should.be.below(1000);
+
+        delete window.$step0;
+        delete window.$step1;
+        delete window.$step2;
+        delete window.$step3;
+        delete window.$step4;
+    });
+
+    it("stops self-triggering effects without freezing", async function () {
+        this.timeout(5000);
+        // This effect writes to the variable it watches — infinite loop
+        // The circular guard should stop it after 100 triggers
+        _hyperscript.evaluate("set $loop to 0");
+        make(
+            `<div _="when $loop changes
+                         set $loop to (it + 1)"></div>`
+        );
+
+        var start = performance.now();
+        await tick();
+        await tick();
+        await tick();
+        var elapsed = performance.now() - start;
+
+        // Should have stopped, not frozen the browser
+        elapsed.should.be.below(2000);
+        // Value should be capped, not Infinity
+        window.$loop.should.be.below(200);
+
+        delete window.$loop;
+    });
+
+    // === Or syntax ===
+
+    it("fires when either expression changes using or", async function () {
+        var div = make(
+            `<div _="when $x or $y changes
+                         put it into me"></div>`
+        );
+
+        _hyperscript.evaluate("set $x to 'from-x'");
+        await tick();
+        div.innerHTML.should.equal("from-x");
+
+        _hyperscript.evaluate("set $y to 'from-y'");
+        await tick();
+        div.innerHTML.should.equal("from-y");
+
+        _hyperscript.evaluate("set $x to 'x-again'");
+        await tick();
+        div.innerHTML.should.equal("x-again");
+
+        delete window.$x;
+        delete window.$y;
+    });
+
+    it("provides the changed value as `it` for each or branch", async function () {
+        _hyperscript.evaluate("set $first to 10");
+        _hyperscript.evaluate("set $second to 20");
+
+        var div = make(
+            `<div _="when $first or $second changes
+                         put it into me"></div>`
+        );
+
+        await tick();
+        // Both fire on initial sync — last one wins (20)
+        var initial = parseInt(div.innerHTML);
+        initial.should.be.oneOf([10, 20]);
+
+        _hyperscript.evaluate("set $first to 99");
+        await tick();
+        div.innerHTML.should.equal("99");
+
+        _hyperscript.evaluate("set $second to 55");
+        await tick();
+        div.innerHTML.should.equal("55");
+
+        delete window.$first;
+        delete window.$second;
+    });
+
+    it("supports three or more expressions with or", async function () {
+        var div = make(
+            `<div _="when $r or $g or $b changes
+                         put it into me"></div>`
+        );
+
+        _hyperscript.evaluate("set $r to 'red'");
+        await tick();
+        div.innerHTML.should.equal("red");
+
+        _hyperscript.evaluate("set $g to 'green'");
+        await tick();
+        div.innerHTML.should.equal("green");
+
+        _hyperscript.evaluate("set $b to 'blue'");
+        await tick();
+        div.innerHTML.should.equal("blue");
+
+        delete window.$r;
+        delete window.$g;
+        delete window.$b;
+    });
+});

--- a/test/index.html
+++ b/test/index.html
@@ -93,6 +93,8 @@
 		<script src="features/init.js"></script>
 		<script src="features/set.js"></script>
 		<script src="features/socket.js"></script>
+		<script src="features/when.js"></script>
+		<script src="features/bind.js"></script>
 
 		<!-- commands -->
 		<script src="commands/add.js"></script>

--- a/www/docs.md
+++ b/www/docs.md
@@ -1180,6 +1180,42 @@ If you have logic that you wish to run when an element is initialized, you can u
 
 The `init` keyword should be followed by a set of commands to execute when the element is loaded.
 
+### Reactivity {#reactivity}
+
+The [`when`](/features/when) feature allows you to react to changes in variables, element properties, or
+attributes. The runtime automatically tracks what the expression reads and re-evaluates when any dependency
+changes.
+
+  ~~~ html
+  <input type="text" id="name" />
+  <h3 _="when #name.value changes
+             put 'Hello, ' + it into me"></h3>
+  <p _="when #name.value changes
+           put it's length + ' characters' into me"></p>
+  ~~~
+
+Both the `<h3>` and the `<p>` react to the same input. Neither element needs to know about
+the other, and you don't have to specify which event to listen for. The runtime handles it.
+
+The `it` keyword refers to the new value. You can watch variables, compound expressions, or multiple
+values with `or`:
+
+  ~~~ html
+  <div _="when ($x + $y) changes put it into me"></div>
+
+  <div _="when $a or $b changes put it into me"></div>
+  ~~~
+
+The [`bind`](/features/bind) feature provides declarative bindings built on top of `when`. Use
+`bind X to Y` for one-way derived values, or `bind X and Y` for two-way sync:
+
+  ~~~ html
+  <input _="bind $name and my.value" />
+  <input _="bind $name and my.value" />
+  ~~~
+
+See the [`when`](/features/when) and [`bind`](/features/bind) pages for full details.
+
 ### Functions {#functions}
 
 Functions in hyperscript are defined by using the [`def` keyword](/features/def).

--- a/www/features/bind.md
+++ b/www/features/bind.md
@@ -1,0 +1,130 @@
+---
+title: bind - ///_hyperscript
+---
+
+## The `bind` Feature
+
+The `bind` feature keeps two values in sync reactively. It is syntax sugar built on top of
+[`when`](/features/when).
+
+### Syntax
+
+```ebnf
+bind <target> to <expression>
+bind <target> and <target>
+```
+
+### One-Way Binding: `bind X to Y`
+
+Creates a derived value. The target always reflects the expression's current value. When any
+dependency of the expression changes, the target updates automatically.
+
+```html
+<!-- Keep an element's text bound to an input -->
+<input type="text" id="name" />
+<h1 _="bind my.textContent to #name.value"></h1>
+```
+
+```html
+<!-- Derive a variable from a compound expression -->
+<div _="bind :fullName to ($firstName + ' ' + $lastName)
+        when :fullName changes
+            put it into me"></div>
+```
+
+```html
+<!-- Keep an attribute in sync with a variable -->
+<div _="bind @data-theme to $theme"></div>
+```
+
+`bind X to Y` is equivalent to:
+
+```
+when Y changes
+    set X to it
+```
+
+### Two-Way Binding: `bind X and Y`
+
+Keeps two values in sync. Changes to either side propagate to the other.
+
+```html
+<input _="bind $username and my.value" />
+```
+
+When the user types in the input, `$username` updates. When `$username` is set programmatically,
+the input's value updates.
+
+`bind X and Y` is equivalent to:
+
+```
+when X changes
+    set Y to it
+end
+when Y changes
+    set X to it
+```
+
+#### Form Input Examples
+
+Two inputs sharing the same variable. Edit either one and the other updates:
+
+```html
+<input type="text" _="bind $msg and my.value" />
+<input type="text" _="bind $msg and my.value" />
+```
+
+Text input with display:
+
+```html
+<input type="text" _="bind $search and my.value" />
+<div _="when $search changes
+            put 'Searching for: ' + it into me"></div>
+```
+
+Checkbox:
+
+```html
+<input type="checkbox" _="bind $darkMode and my.checked" />
+```
+
+Select dropdown:
+
+```html
+<select _="bind $country and my.value">
+    <option value="us">United States</option>
+    <option value="uk">United Kingdom</option>
+</select>
+```
+
+#### Attribute Two-Way Binding
+
+```html
+<div _="bind $theme and @data-theme"></div>
+```
+
+### Infinite Loop Prevention
+
+Two-way binding creates two effects that could trigger each other indefinitely. The reactive
+system prevents this with same-value deduplication: if setting a value to what it already
+equals (`===`), no change is detected and the reverse effect does not fire.
+
+### Supported Targets
+
+Both sides of a `bind` can be any assignable expression:
+
+| Target | Example |
+|--------|---------|
+| Global variable | `$username` |
+| Element variable | `:count` |
+| Attribute | `@data-title` |
+| Property | `my.value` |
+| Style | `*color` |
+
+For `bind X to Y` (one-way), the right side can be any expression since it is only read.
+
+### Relationship to `when`
+
+Everything `bind` does can be written with [`when ... changes`](/features/when) and `set`. Use
+`bind` when you want concise declarative bindings. Use `when` when you need to run arbitrary
+commands in response to changes.

--- a/www/features/when.md
+++ b/www/features/when.md
@@ -1,0 +1,146 @@
+---
+title: when - ///_hyperscript
+---
+
+## The `when` Feature
+
+The `when` feature allows you to run commands whenever an expression's value changes. The runtime
+automatically tracks what the expression reads and re-evaluates it when any dependency changes.
+
+### Syntax
+
+```ebnf
+when <expression> [or <expression>]* changes
+    {<command>}
+[end]
+```
+
+### Description
+
+The `when` feature watches an expression and runs its body whenever the expression's value changes.
+The `it` keyword inside the body refers to the new value of the expression.
+
+If the watched expression already has a value (not `undefined`) when the feature is installed,
+the body fires immediately for initial synchronization. If the value is `undefined`, the body
+waits until the first write.
+
+When the element is removed from the DOM, the reactive effect is automatically cleaned up.
+
+### Watching Element Properties
+
+You can watch any element's properties directly.
+
+```html
+<input type="text" id="name" />
+<h1 _="when #name.value changes
+           put it into me"></h1>
+```
+
+```html
+<input type="checkbox" id="toggle" />
+<div _="when #toggle.checked changes
+            if it is true
+                add .active to me
+            else
+                remove .active from me
+            end"></div>
+```
+
+Property changes are detected through both user interaction (via `input`/`change` events)
+and programmatic changes.
+
+### Watching Attributes
+
+Attribute references (`@data-foo`) are tracked via MutationObserver.
+
+```html
+<div data-title="hello"
+     _="when @data-title changes
+            put it into me"></div>
+```
+
+### Watching Variables
+
+Global variables (`$foo`) and element-scoped variables (`:bar`) are also reactive.
+
+```html
+<div _="when $username changes
+            put it into me"></div>
+```
+
+```html
+<div _="init set :count to 0 end
+        when :count changes
+            put it into me
+        end
+        on click increment :count">0</div>
+```
+
+### Compound Expressions
+
+Dependency tracking is automatic, so compound expressions work naturally. The runtime tracks every
+value the expression reads and re-evaluates when any of them changes.
+
+```html
+<div _="when ($x + $y) changes
+            put it into me"></div>
+```
+
+If the computed result is unchanged (e.g. `$x` goes from 3 to 5 while `$y` goes from 7 to 5),
+the body does not run.
+
+### Multiple Expressions with `or`
+
+You can watch multiple independent expressions separated by `or`. The body runs when any of them
+changes, and `it` refers to the value of the expression that triggered the change.
+
+```html
+<div _="when $x or $y changes
+            put it into me"></div>
+```
+
+This is similar to how the [`on`](/features/on) feature handles `or` for events. You can use
+three or more expressions:
+
+```html
+<div _="when $r or $g or $b changes
+            put it into me"></div>
+```
+
+### Batching
+
+Multiple synchronous writes are batched into a single effect run. If a handler sets `$x` and
+`$y` in the same execution, an effect watching both will only fire once, after both writes
+complete.
+
+### Chained Reactivity
+
+Effects can write to variables that other effects watch, creating reactive chains.
+
+```html
+<div _="when $celsius changes
+            set $fahrenheit to (it * 9 / 5 + 32)"></div>
+
+<div _="when $fahrenheit changes
+            put it into me"></div>
+```
+
+### Examples
+
+Multiple elements reacting to the same source. Each element independently watches the input,
+with no coordination needed between them:
+
+```html
+<input type="text" id="src" />
+<p _="when #src.value changes put it into me"></p>
+<p _="when #src.value changes put it's length + ' chars' into me"></p>
+```
+
+A counter driven from multiple sources. The display doesn't know or care how `$count` is changed:
+
+```html
+<button _="on click increment $count">+1</button>
+<button _="on click decrement $count">-1</button>
+<button _="on click set $count to 0">Reset</button>
+<output _="when $count changes put it into me">0</output>
+```

--- a/www/index.md
+++ b/www/index.md
@@ -143,6 +143,24 @@ _hyperscript has a super-easy way to write [web workers](/docs#workers).
 <div _="install Draggable(dragHandle: .titlebar)">
 ~~~
 
+## Built-in reactivity
+
+<div>
+
+**Watch any value and react when it changes.** Variables, element properties, attributes.
+The runtime tracks dependencies automatically.
+
+[Bind](/features/bind) values together for two-way sync with form inputs.
+
+</div>
+
+~~~html
+<input type="text" id="name" />
+<h1 _="when #name.value changes put it into me"></h1>
+
+<input _="bind $search and my.value" />
+~~~
+
 ## Remember [HyperCard](https://hypercard.org/HyperTalk%20Reference%202.4.pdf)?
 
 <div>

--- a/www/reference.md
+++ b/www/reference.md
@@ -3,15 +3,17 @@
 
 | name                                  | description                                                           | example                         |
 |---------------------------------------|-----------------------------------------------------------------------|---------------------------------|
-| [behavior](/features/behavior)        | Define cross-cutting behaviors that are applied to many HTML elements |                                 |
-| [def](/features/def)                  | Defines a function                                                    | [see details...](/features/def) |
-| [eventsource](/features/event-source) | Subscribe to Server Sent Events (SSE)                                 |                                 |
-| [js](/features/js)                    | Embed JavaScript code at the top level                                | [see details...](/features/js)  |
-| [set](/features/set)                  | Defines a new [element-scoped](/docs#names_and_scoping) variable      |                                 |
-| [init](/features/init)                | Initialization logic to be run when the code is first loaded          |                                 |
-| [on](/features/on)                    | Creates an event listener                                             | `on click log "clicked!"`       |
-| [socket](/features/socket)            | Create a Web Socket                                                   |                                 |
-| [worker](/features/worker)            | Create a Web Worker for asynchronous work                             |                                 |
+| [behavior](/features/behavior)        | Define cross-cutting behaviors that are applied to many HTML elements |                                           |
+| [def](/features/def)                  | Defines a function                                                    | [see details...](/features/def)           |
+| [eventsource](/features/event-source) | Subscribe to Server Sent Events (SSE)                                 |                                           |
+| [js](/features/js)                    | Embed JavaScript code at the top level                                | [see details...](/features/js)            |
+| [set](/features/set)                  | Defines a new [element-scoped](/docs#names_and_scoping) variable      |                                           |
+| [init](/features/init)                | Initialization logic to be run when the code is first loaded          |                                           |
+| [on](/features/on)                    | Creates an event listener                                             | `on click log "clicked!"`                 |
+| [when](/features/when)                | React to changes in variables, properties, or attributes              | `when $x changes ...`                     |
+| [bind](/features/bind)                | Reactive one-way or two-way binding (sugar over `when`)               | `bind @attr to $x`                        |
+| [socket](/features/socket)            | Create a Web Socket                                                   |                                           |
+| [worker](/features/worker)            | Create a Web Worker for asynchronous work                             |                                           |
 
 ## Commands
 


### PR DESCRIPTION
## What

Adds built-in reactivity to hyperscript with automatic dependency tracking.

```html
<input type="text" />
<h1 _="when (previous <input/>)'s value changes
           put it into me"></h1>
```

Or with `bind` (sugar over `when`):

```html
<input type="text" />
<h1 _="bind my textContent to (previous <input/>)'s value"></h1>
```

### `when` - the reactive primitive (effect)

Watches an expression and runs commands when its value changes. Dependencies are tracked automatically.

```html
<!-- Multiple elements react to the same variable -->
<button _="on click increment $count">+1</button>
<button _="on click decrement $count">-1</button>
<output _="when $count changes put it into me">0</output>
<div _="when $count changes
            if it is greater than 10 add .warning to me
            else remove .warning from me end"></div>

<!-- Auto-track compound expressions -->
<div _="when ($price * $quantity) changes put '$' + it into me"></div>

<!-- Watch multiple values with or -->
<div _="when $firstName or $lastName changes
            put $firstName + ' ' + $lastName into me"></div>
```

### `bind` - sugar over `when`

`bind X to Y` (one-way, also known as derived/computed value):
```html
<!-- Bind directly to the element -->
<div _="bind my textContent to '$' + ($price * $quantity)"></div>

<!-- equivalent to -->
<div _="when ($price * $quantity) changes set my textContent to '$' + it"></div>
```

If you need the same derived value in multiple places, bind it to a variable:
```html
<script type="text/hyperscript">
    bind $fullName to $firstName + ' ' + $lastName
</script>

<h1 _="when $fullName changes put it into me"></h1>
<title _="when $fullName changes put it into me"></title>
```

`bind X and Y` (two-way binding):
```html
<input type="checkbox" _="bind $darkMode and my.checked" />

<!-- equivalent to -->
<input type="checkbox"
       _="when $darkMode changes set my.checked to it end
          when my.checked changes set $darkMode to it" />
```

## How it works

Automatic dependency tracking built into the runtime via `createEffect()`. When a reactive effect evaluates an expression, the runtime records every variable, property, and attribute it reads. When any of those change, the expression re-evaluates and the effect fires.

- Variables tracked via `resolveSymbol`/`setSymbol`
- Properties tracked via `resolveProperty` + `input`/`change` events + `defineProperty`
- Attributes tracked via `resolveAttribute` + `MutationObserver`
- Effects batch via `queueMicrotask` and deduplicate same-value writes
- Auto-dispose when element is removed from DOM
- Zero cost when unused (single null check on hot path)

## Tests

37 tests: core behavior, auto-tracking, attribute/property tracking, lifecycle, edge cases (batching, chaining, isolation, error resilience), performance/safety, `or` syntax, and binding.

## Docs

Feature pages for `when` and `bind`, reactivity section in main docs, homepage highlight, reference table.