### PR TITLE
Restore www/_build/widgets.mjs deleted in cc754ce

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ tmp/
 test/.bundle/
 test-results/
 www/_site/
-www/_build/

--- a/www/_build/widgets.mjs
+++ b/www/_build/widgets.mjs
@@ -1,0 +1,55 @@
+export function addWidgets(config) {
+    config.addPairedShortcode('example', (content, caption) => {
+        let rv = "<figure class='box'>\n\n"
+        if (caption) rv += `<figcaption class="allcaps" >Example: ${caption}</figcaption>\n\n`
+        else rv += `<figcaption class="allcaps">Example</figcaption>\n\n`
+        rv += "  ~~~ html"
+        rv += content
+        rv += "~~~\n\n"
+        rv += content
+        rv += "</figure>"
+        return rv
+    })
+
+    function syntax(syntax) {
+        syntax = syntax
+        .replace(/\[\[([\*\+\?])\]\]/g,
+          "<sup>$1</sup>"
+        )
+        .replace(/\[\[([a-zA-Z0-9 ]+)\]\]/g,
+            '<b class="chip syntaxvar"><var>$1</var></b>'
+        )
+
+        return `<code class="syntax">${syntax}</code>`
+    }
+
+    config.addShortcode("syntax", syntax)
+
+    function syntaxify(line) {
+    	return line
+    		.replace(/`([^`]+)`/g, (match, p1) => syntax(p1))
+    }
+
+    config.addPairedShortcode("syntaxes", content => {
+    	const buf = []
+    	const lines = content.split('\n');
+    	let dt = false;
+    	for (const line of lines) {
+	    	if (isJustWhitespace(line)) {
+	    		buf.push(line);
+	    	} else if (!indented(line)) {
+	    		dt = true;
+    			buf.push('\n<dt>' + syntaxify(line));
+    		} else {
+    			if (dt) buf.push('<dd>\n');
+    			dt = false;
+    			buf.push(dedent(line));
+    		}
+    	}
+    	return `<div class="box"><dl class="syntaxes">${buf.join('\n')}</dl></div>`;
+    })
+}
+
+function isJustWhitespace(str) { return /^\s*$/.test(str) }
+function dedent(str) { return str.replace(/^(\t|    )/, '') }
+function indented(str) { return str.startsWith('    ') || str.startsWith('\t') }


### PR DESCRIPTION
## Summary

- Restores `www/_build/widgets.mjs` which was deleted instead of renamed in cc754ce ("mash eleventy into shape")
- Removes `www/_build/` from `.gitignore` so the file is tracked

The eleventy config was updated to import from `./_build/widgets.mjs` but the file was deleted, breaking the docs site build.