### PR TITLE
Generalize input binding and rename always to live

### DIFF
--- a/docs/reactivity-design.md
+++ b/docs/reactivity-design.md
@@ -1,6 +1,6 @@
 # Reactivity Design Notes
 
-Internal reference for the reactive features: `always`, `when`, and `bind`.
+Internal reference for the reactive features: `live`, `when`, and `bind`.
 
 ## Why this works without explicit signals
 
@@ -50,7 +50,7 @@ should be aware that the tracking boundary is the _hyperscript runtime.
 Variables are not signals. `set $count to 0` just stores a value on
 `globalScope` (i.e. `window`). Nothing reactive happens.
 
-Reactivity is created by `always`, `when`, and `bind`. All three use
+Reactivity is created by `live`, `when`, and `bind`. All three use
 `createEffect()` under the hood, which evaluates code with tracking
 enabled. During that evaluation, `resolveSymbol` sees that an effect
 is active and records dependencies. Future writes via `setSymbol` notify
@@ -63,19 +63,21 @@ entirely in the effect and the subscription maps.
 
 Each serves a distinct purpose:
 
-- **`always`** declares relationships. The block runs as one unit with
+- **`live`** declares relationships. The block runs as one unit with
   automatic dependency tracking and re-runs when any dependency changes.
   Used for derived values, DOM updates, and conditional state. For
-  independent tracking, use separate `always` statements.
+  independent tracking, use separate `live` statements.
 
 - **`when`** reacts to changes. Watches a specific expression and runs a
   command body when the value changes. `it` refers to the new value. Used
   for side effects, async work, and events.
 
-- **`bind`** syncs two values bidirectionally. Includes same-value dedup to
-  prevent infinite loops. Used for form inputs and shared state.
+- **`bind`** syncs two values bidirectionally. Includes same-value dedup
+  to prevent infinite loops. When either side resolves to a DOM element,
+  the bound property is auto-detected. Used for form inputs and shared
+  state.
 
-`always` runs its entire command block inside the tracking context (the
+`live` runs its entire command block inside the tracking context (the
 block IS the effect). `when` separates the tracked expression from the
 handler commands. `bind` creates two `when`-style effects pointing at
 each other.

--- a/src/_hyperscript.js
+++ b/src/_hyperscript.js
@@ -38,7 +38,7 @@ import * as InstallFeatureModule from './parsetree/features/install.js';
 import * as JsFeatureModule from './parsetree/features/js.js';
 import * as WhenFeatureModule from './parsetree/features/when.js';
 import * as BindFeatureModule from './parsetree/features/bind.js';
-import * as AlwaysFeatureModule from './parsetree/features/always.js';
+import * as LiveFeatureModule from './parsetree/features/live.js';
 import * as TemplateCommands from './parsetree/commands/template.js';
 
 const globalScope = typeof self !== 'undefined' ? self : (typeof global !== 'undefined' ? global : this);
@@ -81,7 +81,7 @@ kernel.registerModule(InstallFeatureModule);
 kernel.registerModule(JsFeatureModule);
 kernel.registerModule(WhenFeatureModule);
 kernel.registerModule(BindFeatureModule);
-kernel.registerModule(AlwaysFeatureModule);
+kernel.registerModule(LiveFeatureModule);
 kernel.registerModule(TemplateCommands);
 
 // ===== Public API =====

--- a/src/parsetree/features/bind.js
+++ b/src/parsetree/features/bind.js
@@ -1,17 +1,13 @@
 /**
- * Bind Feature - Two-way reactive binding (sugar over `when ... changes`)
+ * Bind Feature - Reactive binding (sugar over `when ... changes`)
  *
- *   bind <variable> and <target>
- *   bind <variable> with <target>
- *     Two-way. Both sides stay in sync. Equivalent to:
- *       when <left> changes set <right> to it end
- *       when <right> changes set <left> to it
+ *   bind <left> and <right>
+ *   bind <left> with <right>
+ *   bind <left> to <right>
+ *     Two-way. Both sides stay in sync.
  *
- *   bind <variable>
- *     Shorthand on form elements. Auto-detects the bound property:
- *       input[type=checkbox/radio]    -> checked
- *       input[type=number/range]      -> valueAsNumber
- *       input, textarea, select       -> value
+ * If either side evaluates to a DOM element, bind auto-detects
+ * the appropriate property (value, checked, valueAsNumber, etc.).
  */
 
 import { Feature } from '../base.js';
@@ -40,17 +36,11 @@ export class BindFeature extends Feature {
             parser.popFollow();
         }
 
-        var right = null;
-        if (parser.matchToken("and") || parser.matchToken("with") || parser.matchToken("to")) {
-            right = parser.requireElement("expression");
+        if (!parser.matchToken("and") && !parser.matchToken("with") && !parser.matchToken("to")) {
+            parser.raiseParseError("bind requires a connector: 'and', 'with', or 'to'");
         }
 
-        if (!_isAssignable(left)) {
-            parser.raiseParseError("bind requires a writable expression, but '" + left.type + "' cannot be assigned to");
-        }
-        if (right && !_isAssignable(right)) {
-            parser.raiseParseError("bind requires a writable expression, but '" + right.type + "' cannot be assigned to");
-        }
+        var right = parser.requireElement("expression");
 
         return new BindFeature(left, right);
     }
@@ -59,16 +49,16 @@ export class BindFeature extends Feature {
         super();
         this.left = left;
         this.right = right;
-        this.displayName = right ? "bind ... and ..." : "bind (shorthand)";
+        this.displayName = "bind";
     }
 
     install(target, source, args, runtime) {
         var feature = this;
         queueMicrotask(function () {
-            if (feature.right) {
-                _twoWayBind(feature.left, feature.right, target, feature, runtime);
-            } else {
-                _shorthandBind(feature.left, target, feature, runtime);
+            try {
+                _bind(feature.left, feature.right, target, feature, runtime);
+            } catch (e) {
+                console.error(e.message || e);
             }
         });
     }
@@ -89,158 +79,177 @@ function _isAssignable(expr) {
 }
 
 /**
- * Two-way bind between two parsed expressions. Left side wins on init:
- * Effect 1 (left→right) runs first, establishing the initial state.
+ * Unified bind: resolve each side, create two effects. Left wins on init.
  */
-function _twoWayBind(left, right, target, feature, runtime) {
-    // Read the current value of a bind side. Class refs are read as
-    // booleans (does the element have this class?) rather than evaluated
-    // as expressions (which would return an ElementCollection).
-    // This mirrors how `add .dark` treats .dark as a class name, not
-    // as a query.
-    function read(expr) {
-        if (expr.type === "classRef") {
-            runtime.resolveAttribute(target, "class");
-            return target.classList.contains(expr.className);
-        }
-        return expr.evaluate(runtime.makeContext(target, feature, target, null));
+function _bind(left, right, target, feature, runtime) {
+    var ctx = runtime.makeContext(target, feature, target, null);
+
+    // Resolve each side: evaluate the expression, check if it's an element
+    var leftSide = _resolveSide(left, target, feature, runtime, ctx);
+    var rightSide = _resolveSide(right, target, feature, runtime, ctx);
+
+    // Validate assignability
+    if (!leftSide.element && !_isAssignable(left)) {
+        throw new Error("bind requires a writable expression on the left side, but '" + left.type + "' cannot be assigned to");
+    }
+    if (!rightSide.element && !_isAssignable(right)) {
+        throw new Error("bind requires a writable expression on the right side, but '" + right.type + "' cannot be assigned to");
     }
 
-    // Effect 1: left changes -> set right
+    // Effect 1: left -> right
     reactivity.createEffect(
-        function () { return read(left); },
-        function (newValue) {
-            var ctx = runtime.makeContext(target, feature, target, null);
-            _assignTo(runtime, right, ctx, newValue);
-        },
+        function () { return leftSide.read(); },
+        function (newValue) { rightSide.write(newValue); },
         { element: target }
     );
-    // Effect 2: right changes -> set left
+
+    // Effect 2: right -> left
     reactivity.createEffect(
-        function () { return read(right); },
-        function (newValue) {
-            var ctx = runtime.makeContext(target, feature, target, null);
-            _assignTo(runtime, left, ctx, newValue);
-        },
+        function () { return rightSide.read(); },
+        function (newValue) { leftSide.write(newValue); },
         { element: target }
     );
+
+    // form.reset() handling: if either side is a form element, listen for reset
+    _setupFormReset(leftSide, rightSide, target, runtime);
 }
 
 /**
- * Shorthand bind: auto-detect property from element type,
- * read/write it directly without a synthetic expression object.
+ * Evaluate an expression and create the appropriate side.
+ * If the expression resolves to a DOM element, create an element side.
+ * Otherwise, create an expression side.
  */
-function _shorthandBind(left, target, feature, runtime) {
-    var propName = _detectProperty(target);
+function _resolveSide(expr, target, feature, runtime, ctx) {
+    var value = expr.evaluate(ctx);
+    if (value instanceof Element) {
+        return _createElementSide(value, runtime);
+    }
+    return _createExpressionSide(expr, target, feature, runtime);
+}
 
-    // Radio buttons work fundamentally differently from other inputs.
-    // The variable holds the value of the selected radio in the group,
-    // not a per-element property. See _radioBind for details.
-    if (propName === "radio") {
-        return _radioBind(left, target, feature, runtime);
+/** Property lookup: INPUT:type -> property name, or TAG -> property name */
+var _bindProperty = {
+    "INPUT:checkbox": "checked",
+    "INPUT:number":   "valueAsNumber",
+    "INPUT:range":    "valueAsNumber",
+    "INPUT":          "value",
+    "TEXTAREA":       "value",
+    "SELECT":         "value",
+};
+
+/**
+ * Create a read/write side for a DOM element, auto-detecting the
+ * appropriate property based on element type.
+ */
+function _createElementSide(element, runtime) {
+    var tag = element.tagName;
+    var type = tag === "INPUT" ? (element.getAttribute("type") || "text") : null;
+
+    // Radio buttons have unique semantics: the variable holds the group's
+    // selected value, not a per-element property.
+    if (tag === "INPUT" && type === "radio") {
+        var radioValue = element.value;
+        return {
+            element: element,
+            read: function () {
+                var checked = runtime.resolveProperty(element, "checked");
+                return checked ? radioValue : undefined;
+            },
+            write: function (value) {
+                element.checked = (value === radioValue);
+            }
+        };
     }
 
-    // Effect 1: variable changes -> write property to element
-    reactivity.createEffect(
-        function () {
-            return left.evaluate(runtime.makeContext(target, feature, target, null));
-        },
-        function (newValue) {
-            target[propName] = newValue;
-        },
-        { element: target }
-    );
+    // Look up property by INPUT:type, then by TAG
+    var prop = _bindProperty[tag + ":" + type] || _bindProperty[tag];
 
-    var isNumeric = propName === "valueAsNumber";
+    // Contenteditable elements
+    if (!prop && element.hasAttribute("contenteditable") && element.getAttribute("contenteditable") !== "false") {
+        prop = "textContent";
+    }
 
-    // Effect 2: element property changes -> write to variable
-    reactivity.createEffect(
-        function () {
-            var val = runtime.resolveProperty(target, propName);
+    // Custom elements with a value property
+    if (!prop && tag.includes("-") && "value" in element) {
+        prop = "value";
+    }
+
+    if (!prop) {
+        throw new Error(
+            "bind cannot auto-detect a property for <" + tag.toLowerCase() + ">. " +
+            "Use an explicit property (e.g. 'bind $var to #el's value')."
+        );
+    }
+
+    var isNumeric = prop === "valueAsNumber";
+    return {
+        element: element,
+        read: function () {
+            var val = runtime.resolveProperty(element, prop);
             return (isNumeric && val !== val) ? null : val;
         },
-        function (newValue) {
-            var ctx = runtime.makeContext(target, feature, target, null);
-            _assignTo(runtime, left, ctx, newValue);
-        },
-        { element: target }
-    );
-
-    // form.reset() changes input values without firing input/change events.
-    // Listen for the reset event and re-sync after the browser resets values.
-    var form = target.closest("form");
-    if (form) {
-        var resetHandler = function () {
-            setTimeout(function () {
-                if (!target.isConnected) return;
-                var val = target[propName];
-                if (isNumeric && val !== val) val = null;
-                var ctx = runtime.makeContext(target, feature, target, null);
-                _assignTo(runtime, left, ctx, val);
-            }, 0);
-        };
-        form.addEventListener("reset", resetHandler);
-        _registerListener(runtime, target, form, "reset", resetHandler);
-    }
+        write: function (value) { element[prop] = value; }
+    };
 }
 
 /**
- * Radio button bind. Unlike normal bind which syncs a variable with a
- * single element's property, radio bind syncs a variable with a GROUP
- * of radio buttons that share the same name attribute.
- *
- * The variable holds the value of the selected radio (e.g. "red").
- * - User clicks a radio: variable is set to that radio's value attribute
- * - Variable changes: the radio whose value matches is checked, others unchecked
- *
- * Each radio in the group has its own bind. They all share the same variable.
+ * Create a read/write side for a parsed expression (variable, attribute, class, etc).
  */
-function _radioBind(left, target, feature, runtime) {
-    var radioValue = target.value;
-    var groupName = target.getAttribute("name");
+function _createExpressionSide(expr, target, feature, runtime) {
+    if (expr.type === "classRef") {
+        return {
+            read: function () {
+                runtime.resolveAttribute(target, "class");
+                return target.classList.contains(expr.className);
+            },
+            write: function (value) {
+                if (value) {
+                    target.classList.add(expr.className);
+                } else {
+                    target.classList.remove(expr.className);
+                }
+            }
+        };
+    }
 
-    // Effect 1: variable changes -> check/uncheck this radio
-    reactivity.createEffect(
-        function () {
-            return left.evaluate(runtime.makeContext(target, feature, target, null));
+    return {
+        read: function () {
+            return expr.evaluate(runtime.makeContext(target, feature, target, null));
         },
-        function (newValue) {
-            target.checked = (newValue === radioValue);
-        },
-        { element: target }
-    );
-
-    // Effect 2: this radio is checked -> set variable to this radio's value
-    // Only fires when this specific radio is clicked (change event).
-    var changeHandler = function () {
-        if (target.checked) {
+        write: function (value) {
             var ctx = runtime.makeContext(target, feature, target, null);
-            _assignTo(runtime, left, ctx, radioValue);
+            _assignTo(runtime, expr, ctx, value);
         }
     };
-    target.addEventListener("change", changeHandler);
-    _registerListener(runtime, target, target, "change", changeHandler);
 }
 
 /**
- * Detect the default property for shorthand bind based on element type.
- * @param {Element} element
- * @returns {string} Property name ("value", "checked", "valueAsNumber", or "radio")
+ * If either side wraps a form element, listen for the form's reset event
+ * and re-sync the binding afterward.
  */
-function _detectProperty(element) {
-    var tag = element.tagName;
-    if (tag === "INPUT") {
-        var type = element.getAttribute("type") || "text";
-        if (type === "radio") return "radio";
-        if (type === "checkbox") return "checked";
-        if (type === "number" || type === "range") return "valueAsNumber";
-        return "value";
-    }
-    if (tag === "TEXTAREA" || tag === "SELECT") return "value";
-    throw new Error(
-        "bind shorthand is not supported on <" + tag.toLowerCase() + "> elements. " +
-        "Use 'bind $var and my value' explicitly."
-    );
+function _setupFormReset(leftSide, rightSide, target, runtime) {
+    _addResetListener(leftSide, rightSide, target, runtime);
+    _addResetListener(rightSide, leftSide, target, runtime);
+}
+
+/**
+ * If source side has an element inside a form, listen for reset and
+ * re-sync source -> dest.
+ */
+function _addResetListener(source, dest, target, runtime) {
+    if (!source.element) return;
+    var form = source.element.closest("form");
+    if (!form) return;
+
+    var resetHandler = function () {
+        setTimeout(function () {
+            if (!target.isConnected) return;
+            var val = source.read();
+            dest.write(val);
+        }, 0);
+    };
+    form.addEventListener("reset", resetHandler);
+    _registerListener(runtime, target, form, "reset", resetHandler);
 }
 
 /** Set an attribute, handling booleans via presence/absence (or "true"/"false" for aria-*) */

--- a/src/parsetree/features/live.js
+++ b/src/parsetree/features/live.js
@@ -1,9 +1,9 @@
 /**
- * Always Feature - Reactive commands that re-run when dependencies change
+ * Live Feature - Reactive commands that re-run when dependencies change
  *
- *   always set $total to ($price * $qty)
+ *   live set $total to ($price * $qty)
  *
- *   always
+ *   live
  *     set $subtotal to ($price * $qty)
  *     set $total to ($subtotal + $tax)
  *     if $total > 100 add .expensive to me else remove .expensive from me end
@@ -17,20 +17,20 @@
 import { Feature } from '../base.js';
 import { reactivity } from '../../core/runtime/reactivity.js';
 
-export class AlwaysFeature extends Feature {
-    static keyword = "always";
+export class LiveFeature extends Feature {
+    static keyword = "live";
 
     constructor(commands) {
         super();
         this.commands = commands;
-        this.displayName = "always";
+        this.displayName = "live";
     }
 
     static parse(parser) {
-        if (!parser.matchToken("always")) return;
+        if (!parser.matchToken("live")) return;
 
         var start = parser.requireElement("commandList");
-        var feature = new AlwaysFeature(start);
+        var feature = new LiveFeature(start);
         parser.ensureTerminated(start);
         parser.setParent(start, feature);
         return feature;

--- a/test/expressions/dom-scope.js
+++ b/test/expressions/dom-scope.js
@@ -170,11 +170,11 @@ test.describe('the dom scope (^var)', () => {
 		await expect(find('output')).toHaveText('2')
 	})
 
-	test('always reacts to ^var changes', async ({html, find}) => {
+	test('live reacts to ^var changes', async ({html, find}) => {
 		await html(
 			`<div _="init set ^name to 'alice'">` +
 			`  <button _="on click set ^name to 'bob'">rename</button>` +
-			`  <output _="always put 'Hello ' + ^name into me">loading</output>` +
+			`  <output _="live put 'Hello ' + ^name into me">loading</output>` +
 			`</div>`
 		)
 		await expect.poll(() => find('output').textContent()).toBe('Hello alice')

--- a/test/features/bind.js
+++ b/test/features/bind.js
@@ -55,7 +55,7 @@ test.describe('the bind feature', () => {
 	test('"with" is a synonym for "and"', async ({html, find, run, evaluate}) => {
 		await html(
 			`<input type="text" id="city-input" value="Paris" />` +
-			`<span _="bind $city with #city-input.value end
+			`<span _="bind $city to #city-input.value end
 			          when $city changes put it into me"></span>`
 		)
 		await expect(find('span')).toHaveText('Paris')
@@ -66,13 +66,13 @@ test.describe('the bind feature', () => {
 	})
 
 	// ================================================================
-	// Shorthand: bind $var
+	// Element auto-detect via 'to me'
 	// ================================================================
 
 	test('shorthand on text input binds to value', async ({html, find, run, evaluate}) => {
 		await html(
 			`<input type="text" value="hello"
-			        _="bind $greeting end
+			        _="bind $greeting to me end
 			           when $greeting changes put it into next <span/>"></input>` +
 			`<span></span>`
 		)
@@ -89,7 +89,7 @@ test.describe('the bind feature', () => {
 	test('shorthand on checkbox binds to checked', async ({html, find, run, evaluate}) => {
 		await run("set $isDarkMode to false")
 		await html(
-			`<input type="checkbox" _="bind $isDarkMode" />` +
+			`<input type="checkbox" _="bind $isDarkMode to me" />` +
 			`<span _="when $isDarkMode changes put it into me"></span>`
 		)
 		await expect.poll(() => find('span').textContent()).toBe('false')
@@ -104,7 +104,7 @@ test.describe('the bind feature', () => {
 
 	test('shorthand on textarea binds to value', async ({html, find, run, evaluate}) => {
 		await html(
-			`<textarea _="bind $bio">Hello world</textarea>` +
+			`<textarea _="bind $bio to me">Hello world</textarea>` +
 			`<span _="when $bio changes put it into me"></span>`
 		)
 		await expect.poll(() => find('span').textContent()).toBe('Hello world')
@@ -116,7 +116,7 @@ test.describe('the bind feature', () => {
 
 	test('shorthand on select binds to value', async ({html, find, run, evaluate}) => {
 		await html(
-			`<select _="bind $country">
+			`<select _="bind $country to me">
 			   <option value="us">United States</option>
 			   <option value="uk">United Kingdom</option>
 			   <option value="fr">France</option>
@@ -130,18 +130,18 @@ test.describe('the bind feature', () => {
 		await evaluate(() => { delete window.$country })
 	})
 
-	test('shorthand on unsupported element produces an error', async ({html, find, evaluate}) => {
+	test('unsupported element: bind to plain div errors', async ({html, find, evaluate}) => {
 		const error = await evaluate(() => {
 			return new Promise(resolve => {
 				var origError = console.error
 				console.error = function(msg) {
-					if (typeof msg === 'string' && msg.includes('bind shorthand')) {
+					if (typeof msg === 'string' && msg.includes('bind cannot auto-detect')) {
 						resolve(msg)
 					}
 					origError.apply(console, arguments)
 				}
 				var wa = document.getElementById('work-area')
-				wa.innerHTML = '<div _="bind $nope"></div>'
+				wa.innerHTML = '<div _="bind $nope to me"></div>'
 				_hyperscript.processNode(wa)
 				setTimeout(() => { console.error = origError; resolve(null) }, 500)
 			})
@@ -156,7 +156,7 @@ test.describe('the bind feature', () => {
 	test('shorthand on type=number preserves number type', async ({html, find, run, evaluate}) => {
 		await run("set $price to 42")
 		await html(
-			`<input type="number" _="bind $price" />` +
+			`<input type="number" _="bind $price to me" />` +
 			`<span _="when $price changes put it into me"></span>`
 		)
 		await new Promise(r => setTimeout(r, 200))
@@ -213,7 +213,7 @@ test.describe('the bind feature', () => {
 	// ================================================================
 
 	test('same value does not re-set input (prevents cursor jump)', async ({html, find, evaluate}) => {
-		await html(`<input type="text" value="hello" _="bind $message" />`)
+		await html(`<input type="text" value="hello" _="bind $message to me" />`)
 		await new Promise(r => setTimeout(r, 100))
 
 		const setterWasCalled = await evaluate(() => {
@@ -236,7 +236,7 @@ test.describe('the bind feature', () => {
 
 	test('external JS property write does not sync (known limitation)', async ({html, find, run, evaluate}) => {
 		await html(
-			`<input type="text" value="original" _="bind $searchTerm" />` +
+			`<input type="text" value="original" _="bind $searchTerm to me" />` +
 			`<span _="when $searchTerm changes put it into me"></span>`
 		)
 		await expect.poll(() => find('span').textContent()).toBe('original')
@@ -252,7 +252,7 @@ test.describe('the bind feature', () => {
 	test('form.reset() syncs variable back to default value', async ({html, find, run, evaluate}) => {
 		await html(
 			`<form id="test-form">` +
-			`  <input type="text" value="default" _="bind $formField" />` +
+			`  <input type="text" value="default" _="bind $formField to me" />` +
 			`</form>` +
 			`<span _="when $formField changes put it into me"></span>`
 		)
@@ -274,9 +274,9 @@ test.describe('the bind feature', () => {
 	test('clicking a radio sets the variable to its value', async ({html, find, run, evaluate}) => {
 		await run("set $color to 'red'")
 		await html(
-			`<input type="radio" name="color" value="red" _="bind $color" />` +
-			`<input type="radio" name="color" value="blue" _="bind $color" />` +
-			`<input type="radio" name="color" value="green" _="bind $color" />` +
+			`<input type="radio" name="color" value="red" _="bind $color to me" />` +
+			`<input type="radio" name="color" value="blue" _="bind $color to me" />` +
+			`<input type="radio" name="color" value="green" _="bind $color to me" />` +
 			`<span _="when $color changes put it into me"></span>`
 		)
 		await expect.poll(() => find('span').textContent()).toBe('red')
@@ -292,9 +292,9 @@ test.describe('the bind feature', () => {
 	test('setting variable programmatically checks the matching radio', async ({html, find, run, evaluate}) => {
 		await run("set $size to 'small'")
 		await html(
-			`<input type="radio" name="size" value="small" _="bind $size" />` +
-			`<input type="radio" name="size" value="medium" _="bind $size" />` +
-			`<input type="radio" name="size" value="large" _="bind $size" />`
+			`<input type="radio" name="size" value="small" _="bind $size to me" />` +
+			`<input type="radio" name="size" value="medium" _="bind $size to me" />` +
+			`<input type="radio" name="size" value="large" _="bind $size to me" />`
 		)
 		await new Promise(r => setTimeout(r, 100))
 		expect(await evaluate(() => document.querySelector('input[value="small"]').checked)).toBe(true)
@@ -312,9 +312,9 @@ test.describe('the bind feature', () => {
 	test('initial value checks the correct radio on load', async ({html, find, run, evaluate}) => {
 		await run("set $fruit to 'banana'")
 		await html(
-			`<input type="radio" name="fruit" value="apple" _="bind $fruit" />` +
-			`<input type="radio" name="fruit" value="banana" _="bind $fruit" />` +
-			`<input type="radio" name="fruit" value="cherry" _="bind $fruit" />`
+			`<input type="radio" name="fruit" value="apple" _="bind $fruit to me" />` +
+			`<input type="radio" name="fruit" value="banana" _="bind $fruit to me" />` +
+			`<input type="radio" name="fruit" value="cherry" _="bind $fruit to me" />`
 		)
 		await new Promise(r => setTimeout(r, 100))
 		expect(await evaluate(() => document.querySelector('input[value="apple"]').checked)).toBe(false)
@@ -501,14 +501,123 @@ test.describe('the bind feature', () => {
 	})
 
 	// ================================================================
+	// Element auto-detection
+	// ================================================================
+
+	test('bind variable to element by id auto-detects value', async ({html, find, run, evaluate}) => {
+		await html(
+			`<input type="text" id="name-field" value="" />` +
+			`<div _="bind $name to #name-field"></div>`
+		)
+		await run("set $name to 'Alice'")
+		await expect.poll(() => evaluate(() => document.getElementById('name-field').value)).toBe('Alice')
+
+		await evaluate(() => {
+			var input = document.getElementById('name-field')
+			input.value = 'Bob'
+			input.dispatchEvent(new Event('input', { bubbles: true }))
+		})
+		await expect.poll(() => evaluate(() => window.$name)).toBe('Bob')
+		await evaluate(() => { delete window.$name })
+	})
+
+	test('bind variable to checkbox by id auto-detects checked', async ({html, find, run, evaluate}) => {
+		await run("set $agreed to false")
+		await html(
+			`<input type="checkbox" id="agree-cb" />` +
+			`<div _="bind $agreed to #agree-cb"></div>`
+		)
+		await new Promise(r => setTimeout(r, 100))
+		expect(await evaluate(() => document.getElementById('agree-cb').checked)).toBe(false)
+
+		await run("set $agreed to true")
+		await expect.poll(() => evaluate(() => document.getElementById('agree-cb').checked)).toBe(true)
+		await evaluate(() => { delete window.$agreed })
+	})
+
+	test('bind variable to number input by id auto-detects valueAsNumber', async ({html, find, run, evaluate}) => {
+		await run("set $qty to 5")
+		await html(
+			`<input type="number" id="qty-input" />` +
+			`<div _="bind $qty to #qty-input"></div>`
+		)
+		await expect.poll(() => evaluate(() => document.getElementById('qty-input').valueAsNumber)).toBe(5)
+		expect(await evaluate(() => typeof window.$qty)).toBe('number')
+		await evaluate(() => { delete window.$qty })
+	})
+
+	test('bind element to element: both sides auto-detect', async ({html, find, evaluate}) => {
+		await html(
+			`<input type="range" id="range-slider" value="50" />` +
+			`<input type="number" _="bind me to #range-slider" />`
+		)
+		await new Promise(r => setTimeout(r, 100))
+		expect(await evaluate(() => document.querySelector('#work-area input[type=number]').valueAsNumber)).toBe(50)
+
+		await evaluate(() => {
+			var slider = document.getElementById('range-slider')
+			slider.value = '75'
+			slider.dispatchEvent(new Event('input', { bubbles: true }))
+		})
+		await expect.poll(() =>
+			evaluate(() => document.querySelector('#work-area input[type=number]').valueAsNumber)
+		).toBe(75)
+	})
+
+	test('element on left wins on init: prepopulated input pushes into variable', async ({html, find, run, evaluate}) => {
+		await html(`<input type="text" value="Bob" _="bind me to $name" />`)
+		await new Promise(r => setTimeout(r, 100))
+		expect(await evaluate(() => window.$name)).toBe('Bob')
+		expect(await evaluate(() => document.querySelector('#work-area input').value)).toBe('Bob')
+		await evaluate(() => { delete window.$name })
+	})
+
+	// ================================================================
+	// Contenteditable and custom elements
+	// ================================================================
+
+	test('bind to contenteditable element auto-detects textContent', async ({html, find, run, evaluate}) => {
+		await html(`<div contenteditable="true" _="bind $text to me">initial</div>`)
+		await new Promise(r => setTimeout(r, 100))
+		expect(await evaluate(() => window.$text)).toBe('initial')
+
+		await run("set $text to 'updated'")
+		await expect.poll(() =>
+			evaluate(() => document.querySelector('#work-area div[contenteditable]').textContent)
+		).toBe('updated')
+		await evaluate(() => { delete window.$text })
+	})
+
+	test('bind to custom element with value property auto-detects value', async ({html, find, run, evaluate}) => {
+		await evaluate(() => {
+			if (!customElements.get('test-input')) {
+				class TestInput extends HTMLElement {
+					constructor() { super(); this._value = ''; }
+					get value() { return this._value; }
+					set value(v) {
+						this._value = v;
+						this.dispatchEvent(new Event('input', { bubbles: true }));
+					}
+				}
+				customElements.define('test-input', TestInput);
+			}
+		})
+
+		await html(`<test-input _="bind $custom to me"></test-input>`)
+		await run("set $custom to 'hello'")
+		await expect.poll(() => evaluate(() => document.querySelector('#work-area test-input').value)).toBe('hello')
+		await evaluate(() => { delete window.$custom })
+	})
+
+	// ================================================================
 	// Cleanup
 	// ================================================================
 
 	test('radio change listener is removed on cleanup', async ({html, evaluate, run}) => {
 		await run("set $color to 'red'")
 		await html(
-			`<input type="radio" name="color" value="red" _="bind $color" checked />` +
-			`<input type="radio" name="color" value="blue" _="bind $color" />`
+			`<input type="radio" name="color" value="red" _="bind $color to me" checked />` +
+			`<input type="radio" name="color" value="blue" _="bind $color to me" />`
 		)
 		await evaluate(() => new Promise(r => setTimeout(r, 50)))
 
@@ -535,7 +644,7 @@ test.describe('the bind feature', () => {
 		await run("set $val to 'initial'")
 		await html(
 			`<form>` +
-			`<input type="text" id="binput" value="initial" _="bind $val" />` +
+			`<input type="text" id="binput" value="initial" _="bind $val to me" />` +
 			`<button type="reset">Reset</button>` +
 			`</form>`
 		)

--- a/test/features/live.js
+++ b/test/features/live.js
@@ -1,6 +1,6 @@
 import {test, expect} from '../fixtures.js'
 
-test.describe('the always feature', () => {
+test.describe('the live feature', () => {
 
 	// ================================================================
 	// Single statement
@@ -10,7 +10,7 @@ test.describe('the always feature', () => {
 		await run("set $price to 10")
 		await run("set $qty to 3")
 		await html(
-			`<div _="always set $total to ($price * $qty) end
+			`<div _="live set $total to ($price * $qty) end
 			         when $total changes put it into me"></div>`
 		)
 		await expect(find('div')).toHaveText('30')
@@ -22,7 +22,7 @@ test.describe('the always feature', () => {
 
 	test('updates DOM text reactively with put', async ({html, find, run, evaluate}) => {
 		await run("set $greeting to 'world'")
-		await html(`<div _="always put 'hello ' + $greeting into me"></div>`)
+		await html(`<div _="live put 'hello ' + $greeting into me"></div>`)
 		await expect.poll(() => find('div').textContent()).toBe('hello world')
 
 		await run("set $greeting to 'there'")
@@ -32,7 +32,7 @@ test.describe('the always feature', () => {
 
 	test('sets an attribute reactively', async ({html, find, run, evaluate}) => {
 		await run("set $theme to 'light'")
-		await html(`<div _="always set my @data-theme to $theme"></div>`)
+		await html(`<div _="live set my @data-theme to $theme"></div>`)
 		await expect(find('div')).toHaveAttribute('data-theme', 'light')
 
 		await run("set $theme to 'dark'")
@@ -42,7 +42,7 @@ test.describe('the always feature', () => {
 
 	test('sets a style reactively', async ({html, find, run, evaluate}) => {
 		await run("set $opacity to 1")
-		await html(`<div _="always set *opacity to $opacity">visible</div>`)
+		await html(`<div _="live set *opacity to $opacity">visible</div>`)
 		await new Promise(r => setTimeout(r, 100))
 
 		await run("set $opacity to 0.5")
@@ -55,7 +55,7 @@ test.describe('the always feature', () => {
 	test('puts a computed dollar amount into the DOM', async ({html, find, run, evaluate}) => {
 		await run("set $price to 10")
 		await run("set $qty to 2")
-		await html(`<div _="always put '$' + ($price * $qty) into me"></div>`)
+		await html(`<div _="live put '$' + ($price * $qty) into me"></div>`)
 		await expect.poll(() => find('div').textContent()).toBe('$20')
 
 		await run("set $qty to 5")
@@ -73,7 +73,7 @@ test.describe('the always feature', () => {
 		await html(
 			`<span id="w" _="when $doubleWidth changes put it into me"></span>` +
 			`<span id="h" _="when $doubleHeight changes put it into me"></span>` +
-			`<div _="always
+			`<div _="live
 			           set $doubleWidth to ($width * 2)
 			           set $doubleHeight to ($height * 2)
 			         end"></div>`
@@ -92,14 +92,14 @@ test.describe('the always feature', () => {
 		})
 	})
 
-	test('separate always statements create independent effects', async ({html, find, run, evaluate}) => {
+	test('separate live statements create independent effects', async ({html, find, run, evaluate}) => {
 		await run("set $width to 100")
 		await run("set $height to 200")
 		await html(
 			`<span id="w" _="when $doubleWidth changes put it into me"></span>` +
 			`<span id="h" _="when $doubleHeight changes put it into me"></span>` +
-			`<div _="always set $doubleWidth to ($width * 2) end
-			         always set $doubleHeight to ($height * 2)"></div>`
+			`<div _="live set $doubleWidth to ($width * 2) end
+			         live set $doubleHeight to ($height * 2)"></div>`
 		)
 		await expect.poll(() => find('#w').textContent()).toBe('200')
 		await expect.poll(() => find('#h').textContent()).toBe('400')
@@ -120,7 +120,7 @@ test.describe('the always feature', () => {
 		await run("set $qty to 3")
 		await run("set $tax to 5")
 		await html(
-			`<div _="always
+			`<div _="live
 			           set $subtotal to ($price * $qty)
 			           set $total to ($subtotal + $tax)
 			         end
@@ -140,13 +140,13 @@ test.describe('the always feature', () => {
 	})
 
 	// ================================================================
-	// if/else inside always
+	// if/else inside live
 	// ================================================================
 
 	test('toggles a class based on a boolean variable', async ({html, find, run, evaluate}) => {
 		await run("set $isActive to false")
 		await html(
-			`<div _="always
+			`<div _="live
 			           if $isActive add .active to me else remove .active from me end
 			         end">test</div>`
 		)
@@ -164,7 +164,7 @@ test.describe('the always feature', () => {
 	test('toggles display style based on a boolean variable', async ({html, find, run, evaluate}) => {
 		await run("set $isVisible to true")
 		await html(
-			`<div _="always
+			`<div _="live
 			           if $isVisible set *display to 'block' else set *display to 'none' end
 			         end">content</div>`
 		)
@@ -190,7 +190,7 @@ test.describe('the always feature', () => {
 
 	test('effects stop when element is removed from DOM', async ({html, find, run, evaluate}) => {
 		await run("set $message to 'initial'")
-		await html(`<div _="always put $message into me"></div>`)
+		await html(`<div _="live put $message into me"></div>`)
 		await expect.poll(() => find('div').textContent()).toBe('initial')
 
 		await evaluate(() => document.querySelector('#work-area div').remove())
@@ -208,7 +208,7 @@ test.describe('the always feature', () => {
 		await run("set $firstName to 'Alice'")
 		await run("set $lastName to 'Smith'")
 		await html(
-			`<div _="always
+			`<div _="live
 			           if $showFirst put $firstName into me else put $lastName into me end
 			         end"></div>`
 		)
@@ -241,12 +241,12 @@ test.describe('the always feature', () => {
 	// Multiple features on same element
 	// ================================================================
 
-	test('multiple always on same element work independently', async ({html, find, run, evaluate}) => {
+	test('multiple live on same element work independently', async ({html, find, run, evaluate}) => {
 		await run("set $firstName to 'Alice'")
 		await run("set $age to 30")
 		await html(
-			`<div _="always set my @data-name to $firstName end
-			         always set my @data-age to $age"></div>`
+			`<div _="live set my @data-name to $firstName end
+			         live set my @data-age to $age"></div>`
 		)
 		await expect(find('div')).toHaveAttribute('data-name', 'Alice')
 		await expect(find('div')).toHaveAttribute('data-age', '30')
@@ -257,10 +257,10 @@ test.describe('the always feature', () => {
 		await evaluate(() => { delete window.$firstName; delete window.$age })
 	})
 
-	test('always and when on same element do not interfere', async ({html, find, run, evaluate}) => {
+	test('live and when on same element do not interfere', async ({html, find, run, evaluate}) => {
 		await run("set $status to 'online'")
 		await html(
-			`<div _="always set my @data-status to $status end
+			`<div _="live set my @data-status to $status end
 			         when $status changes put 'Status: ' + it into me"></div>`
 		)
 		await expect(find('div')).toHaveAttribute('data-status', 'online')
@@ -272,12 +272,12 @@ test.describe('the always feature', () => {
 		await evaluate(() => { delete window.$status })
 	})
 
-	test('bind and always on same element do not interfere', async ({html, find, run, evaluate}) => {
+	test('bind and live on same element do not interfere', async ({html, find, run, evaluate}) => {
 		await run("set $username to 'alice'")
 		await html(
 			`<input type="text" value="alice"
-			        _="bind $username end
-			           always set my @data-mirror to $username" />` +
+			        _="bind $username to me end
+			           live set my @data-mirror to $username" />` +
 			`<span _="when $username changes put it into me"></span>`
 		)
 		await expect.poll(() => find('span').textContent()).toBe('alice')
@@ -291,7 +291,7 @@ test.describe('the always feature', () => {
 
 	test('reactive effects are stopped on cleanup', async ({html, find, run, evaluate}) => {
 		await run("set $count to 0")
-		await html(`<div id="d1" _="always put $count into me"></div>`)
+		await html(`<div id="d1" _="live put $count into me"></div>`)
 		await expect.poll(() => find('#d1').textContent()).toBe('0')
 
 		// Clean up the element (but keep it in DOM to detect if effect still fires)

--- a/test/features/reactive-properties.js
+++ b/test/features/reactive-properties.js
@@ -33,9 +33,9 @@ test.describe('reactive property tracking', () => {
 		await expect.poll(() => find('output').textContent()).toBe('updated')
 	})
 
-	test('always block tracks property reads on plain objects', async ({html, find, run, evaluate}) => {
+	test('live block tracks property reads on plain objects', async ({html, find, run, evaluate}) => {
 		await run("set $config to {label: 'initial'}")
-		await html(`<output _="always put $config's label into me"></output>`)
+		await html(`<output _="live put $config's label into me"></output>`)
 		await expect.poll(() => find('output').textContent()).toBe('initial')
 
 		await run("set $config's label to 'changed'")

--- a/test/features/when.js
+++ b/test/features/when.js
@@ -438,7 +438,7 @@ test.describe('the when feature', () => {
 		await html(
 			`<span id="d-b" _="when $a changes set $b to (it * 2)"></span>` +
 			`<span id="d-c" _="when $a changes set $c to (it * 3)"></span>` +
-			`<div _="always increment :runs then put ($b + $c) + ' (runs:' + :runs + ')' into me"></div>`
+			`<div _="live increment :runs then put ($b + $c) + ' (runs:' + :runs + ')' into me"></div>`
 		)
 		await new Promise(r => setTimeout(r, 100))
 		await run("set $a to 10")

--- a/test/scratch.html
+++ b/test/scratch.html
@@ -83,7 +83,7 @@ var HS_KEYWORDS = [
 	"send", "take", "log", "call", "wait", "settle", "repeat", "for", "in",
 	"while", "until", "from", "to", "by", "increment", "decrement", "default",
 	"transition", "fetch", "throw", "return", "exit", "halt", "async", "tell",
-	"go", "hide", "show", "with", "when", "changes", "always", "bind", "and",
+	"go", "hide", "show", "with", "when", "changes", "live", "bind", "and",
 	"or", "not", "no", "is", "am", "the", "a", "an", "of", "closest", "next",
 	"previous", "first", "last", "random", "as", "my", "me", "it", "its",
 	"you", "your", "yourself", "result", "event", "target", "detail", "sender",

--- a/www/docs.md
+++ b/www/docs.md
@@ -1404,12 +1404,12 @@ For simple cases, [`on`](/features/on) is the right tool. But when a value can b
 changed from multiple places, or when you don't want to list every source of change,
 reactive features let you just declare what you want and it stays in sync.
 
-**[`always`](/features/always)** keeps the DOM in sync with values:
+**[`live`](/features/live)** keeps the DOM in sync with values:
 
   ~~~ html
   <button _="on click increment $count">+1</button>
   <button _="on click set $count to 0">Reset</button>
-  <output _="always put 'Count: ' + $count into me"></output>
+  <output _="live put 'Count: ' + $count into me"></output>
   ~~~
 
 **[`when`](/features/when)** reacts to changes with side effects or chained logic:
@@ -1426,7 +1426,7 @@ reactive features let you just declare what you want and it stays in sync.
   <body _="bind .dark and #dark-toggle's checked">
   ~~~
 
-See the [`always`](/features/always), [`when`](/features/when), and [`bind`](/features/bind) pages
+See the [`live`](/features/live), [`when`](/features/when), and [`bind`](/features/bind) pages
 for full details.
 
 ### Functions {#functions}

--- a/www/features/bind.md
+++ b/www/features/bind.md
@@ -7,19 +7,18 @@ title: bind - ///_hyperscript
 The `bind` feature keeps two values in sync (two-way). Use it for form inputs and
 shared state.
 
-For one-way derived values, see [`always`](/features/always).
+For one-way derived values, see [`live`](/features/live).
 For reacting to changes with side effects, see [`when`](/features/when).
 
 ### Syntax
 
 ```ebnf
+bind <expression> to <expression>
 bind <expression> and <expression>
 bind <expression> with <expression>
-bind <expression> to <expression>
-bind <variable>
 ```
 
-The keywords `and`, `with`, and `to` are interchangeable.
+The keywords `to`, `and`, and `with` are interchangeable.
 
 ### Two-Way Binding
 
@@ -29,21 +28,21 @@ Toggle a class based on a checkbox:
 
 ```html
 <input type="checkbox" id="dark-toggle" />
-<body _="bind .dark and #dark-toggle's checked">
+<body _="bind .dark to #dark-toggle's checked">
 ```
 
 Keep an attribute in sync with a nearby input:
 
 ```html
 <input type="text" id="title-input" />
-<h1 _="bind @data-title and #title-input's value">
+<h1 _="bind @data-title to #title-input's value">
 ```
 
 Sync two inputs together:
 
 ```html
 <input type="range" id="slider" />
-<input type="number" _="bind my value and #slider's value" />
+<input type="number" _="bind my value to #slider's value" />
 ```
 
 #### Boolean Attributes
@@ -52,41 +51,41 @@ When binding a boolean value to an attribute, standard attributes use
 presence/absence. ARIA attributes use `"true"`/`"false"` strings:
 
 ```html
-<div _="bind @data-active and #toggle's checked">
-<div _="bind @aria-hidden and $isHidden">
+<div _="bind @data-active to #toggle's checked">
+<div _="bind @aria-hidden to $isHidden">
 ```
 
-### Initialization
+### Element Auto-Detection
 
-When both sides have values on init, the **left side wins**:
+When either side of a bind resolves to a DOM element (via `me`, `#id`, or a
+query), the bound property is detected automatically:
 
-```html
-<!-- The input's current value drives the heading on init -->
-<input type="text" id="title-input" value="From Input" />
-<h1 data-title="From HTML"
-    _="bind #title-input's value and @data-title">
-```
-
-If either side is `undefined` or `null`, the other side wins regardless of position.
-
-### Shorthand: `bind $var`
-
-On form elements, you can omit the second argument. The bound property is detected
-automatically from the element type:
-
-| Element | Binds to |
-|---------|----------|
-| `<input type="text">` | `my value` |
-| `<input type="number">` | `my valueAsNumber` (preserves number type) |
-| `<input type="checkbox">` | `my checked` |
-| `<input type="radio">` | group (see below) |
-| `<textarea>` | `my value` |
-| `<select>` | `my value` |
+| Element | Detected property |
+|---------|-------------------|
+| `<input type="text">` | `value` |
+| `<input type="number">`, `<input type="range">` | `valueAsNumber` (preserves number type) |
+| `<input type="checkbox">` | `checked` |
+| `<input type="radio">` | radio group value (see below) |
+| `<textarea>` | `value` |
+| `<select>` | `value` |
+| `<* contenteditable>` | `textContent` |
+| Custom elements with a `value` property | `value` |
 
 ```html
-<input type="text" _="bind $name" />
-<input type="checkbox" _="bind $darkMode" />
-<select _="bind $country">...</select>
+<!-- auto-detects 'value' on the input -->
+<input type="text" _="bind $name to me" />
+
+<!-- auto-detects 'checked' on the checkbox -->
+<input type="checkbox" _="bind $darkMode to me" />
+
+<!-- bind to an element by id — auto-detects 'value' -->
+<div _="bind $search to #search-input" />
+
+<!-- both sides auto-detect -->
+<input type="number" _="bind me to #slider" />
+
+<!-- explicit property still works -->
+<div _="bind $dark to #toggle's checked" />
 ```
 
 #### Radio Button Groups
@@ -95,13 +94,27 @@ Radio buttons are grouped by `name` attribute. The variable holds the value of t
 selected radio. Each radio in the group has its own `bind`:
 
 ```html
-<input type="radio" name="size" value="small" _="bind $size" />
-<input type="radio" name="size" value="medium" _="bind $size" />
-<input type="radio" name="size" value="large" _="bind $size" />
+<input type="radio" name="size" value="small" _="bind $size to me" />
+<input type="radio" name="size" value="medium" _="bind $size to me" />
+<input type="radio" name="size" value="large" _="bind $size to me" />
 ```
 
 Clicking a radio sets `$size` to that radio's `value` attribute. Setting `$size`
 programmatically checks the matching radio and unchecks the others.
+
+### Initialization
+
+When both sides have values on init, the **left side wins**:
+
+```html
+<!-- The input's current value drives the variable on init -->
+<input type="text" value="Bob" _="bind me to $name" />
+
+<!-- The variable drives the input on init -->
+<input type="text" _="bind $name to me" />
+```
+
+If either side is `undefined` or `null`, the other side wins regardless of position.
 
 ### Infinite Loop Prevention
 

--- a/www/features/live.md
+++ b/www/features/live.md
@@ -1,10 +1,10 @@
 ---
-title: always - ///_hyperscript
+title: live - ///_hyperscript
 ---
 
-## The `always` Feature
+## The `live` Feature
 
-The `always` feature declares reactive commands that re-run whenever their dependencies
+The `live` feature declares reactive commands that re-run whenever their dependencies
 change.
 
 For reacting to changes with side effects, see [`when`](/features/when).
@@ -13,9 +13,9 @@ For two-way sync, see [`bind`](/features/bind).
 ### Syntax
 
 ```ebnf
-always <command>
+live <command>
 
-always
+live
     {<command>}
 end
 ```
@@ -38,14 +38,14 @@ or an htmx response? With `on`, you have to list every source:
            on htmx:afterSwap from body put $count into me">
 ```
 
-With `always`, you just say what you want and it stays in sync no matter what changes
+With `live`, you just say what you want and it stays in sync no matter what changes
 `$count`:
 
 ```html
-<output _="always put $count into me">
+<output _="live put $count into me">
 ```
 
-Add a new source of change tomorrow and the `always` version just works.
+Add a new source of change tomorrow and the `live` version just works.
 
 ### Single Statement
 
@@ -53,26 +53,26 @@ Add a new source of change tomorrow and the `always` version just works.
 <button _="on click increment $count">+1</button>
 <button _="on click decrement $count">-1</button>
 <button _="on click set $count to 0">Reset</button>
-<output _="always put 'Count: ' + $count into me"></output>
+<output _="live put 'Count: ' + $count into me"></output>
 ```
 
 Works with any command:
 
 ```html
 <!-- Derived variable -->
-<span _="always set $total to (#price's value * #qty's value)">
+<span _="live set $total to (#price's value * #qty's value)">
 
 <!-- Computed DOM update -->
-<span _="always put '$' + $total into me">
+<span _="live put '$' + $total into me">
 
 <!-- Reactive attribute -->
-<div _="always set my @data-theme to $theme">
+<div _="live set my @data-theme to $theme">
 
 <!-- Reactive style -->
-<div _="always set *opacity to $visible and 1 or 0">
+<div _="live set *opacity to $visible and 1 or 0">
 
 <!-- Conditional class -->
-<div _="always if $active add .on to me else remove .on from me end">
+<div _="live if $active add .on to me else remove .on from me end">
 ```
 
 ### Block Form
@@ -81,7 +81,7 @@ Group multiple reactive commands in a block. All commands run top to bottom
 as one unit, just like any other block in _hyperscript:
 
 ```html
-<div _="always
+<div _="live
           set $subtotal to (#price's value * #qty's value)
           set $total to ($subtotal + $tax)
           put '$' + $total into me
@@ -94,13 +94,13 @@ When any dependency changes (`$price`, `$qty`, `$tax`), the entire block re-runs
 ### Independent Effects
 
 If you want each reactive command to track its own dependencies independently,
-use separate `always` statements:
+use separate `live` statements:
 
 ```html
-<div _="always set $subtotal to (#price's value * #qty's value) end
-        always set $total to ($subtotal + $tax) end
-        always put '$' + $total into me end
-        always if $total > 100 add .expensive to me else remove .expensive from me end">
+<div _="live set $subtotal to (#price's value * #qty's value) end
+        live set $total to ($subtotal + $tax) end
+        live put '$' + $total into me end
+        live if $total > 100 add .expensive to me else remove .expensive from me end">
 ```
 
 ### How It Works
@@ -111,14 +111,14 @@ When any dependency changes, the block re-runs.
 
 ### Cleanup
 
-When the element is removed from the DOM, all its `always` effects are automatically
+When the element is removed from the DOM, all its `live` effects are automatically
 stopped.
 
-### Choosing Between `always`, `when`, and `bind`
+### Choosing Between `live`, `when`, and `bind`
 
 | I want to... | Use |
 |---|---|
-| Keep the DOM in sync with values | `always` |
+| Keep the DOM in sync with values | `live` |
 | React to a change with side effects or chained logic | `when` |
 | Keep a variable and a form input in sync | `bind` |
 

--- a/www/features/when.md
+++ b/www/features/when.md
@@ -7,7 +7,7 @@ title: when - ///_hyperscript
 The `when` feature runs commands in response to a value change. Use it when you need to
 *react* with side effects or chained effects.
 
-For declaring relationships (derived values, DOM updates), see [`always`](/features/always).
+For declaring relationships (derived values, DOM updates), see [`live`](/features/live).
 For two-way sync, see [`bind`](/features/bind).
 
 ### Syntax

--- a/www/playground.html
+++ b/www/playground.html
@@ -253,7 +253,7 @@ var HS_KEYWORDS = [
     "send", "take", "log", "call", "wait", "settle", "repeat", "for", "in",
     "while", "until", "from", "to", "by", "increment", "decrement", "default",
     "transition", "fetch", "throw", "return", "exit", "halt", "async", "tell",
-    "go", "hide", "show", "with", "when", "changes", "always", "bind", "and",
+    "go", "hide", "show", "with", "when", "changes", "live", "bind", "and",
     "or", "not", "no", "is", "am", "the", "a", "an", "of", "closest", "next",
     "previous", "first", "last", "random", "as", "my", "me", "it", "its",
     "you", "your", "yourself", "result", "event", "target", "detail", "sender",

--- a/www/reference.md
+++ b/www/reference.md
@@ -12,9 +12,9 @@ Features are top-level constructs that define the behavior of an element. Every 
 | [behavior](/features/behavior)        | Define cross-cutting behaviors that are applied to many HTML elements |                                           |
 | [install](/features/behavior)         | Install a behavior onto the current element                           | `install Draggable`                       |
 | [js](/features/js)                    | Embed JavaScript code at the top level                                | [see details...](/features/js)            |
-| [always](/features/always)            | Declare reactive commands that re-run when dependencies change        | `always set $total to ($price * $qty)`    |
+| [live](/features/live)                | Declare reactive commands that re-run when dependencies change        | `live set $total to ($price * $qty)`      |
 | [when](/features/when)                | React to value changes with side effects, async, or events            | `when $x changes ...`                     |
-| [bind](/features/bind)                | Two-way sync between any two values                                   | `bind .dark and #toggle's checked`        |
+| [bind](/features/bind)                | Two-way sync between values with element auto-detection               | `bind $name to me`                        |
 
 ### Extensions
 


### PR DESCRIPTION
Bind changes:
- Unify _twoWayBind, _shorthandBind, and _radioBind into a single adapter-based _bind function
- Auto-detect element properties (value, checked, valueAsNumber, textContent for contenteditable, value for custom elements)
- Remove bare 'bind $var' shorthand (now requires 'bind $var to me')
- Move assignability validation to install time for element expressions
- Wrap bind install in try/catch for proper error reporting
- Update all existing tests, add 7 new tests, update docs

Rename always -> live:
- Rename feature keyword, source file, test file, and doc file
- Update all references across tests, docs, and playground