### PR TITLE
fix hdb console form parse error caused by duplicate end

### DIFF
--- a/src/ext/hdb.js
+++ b/src/ext/hdb.js
@@ -335,7 +335,7 @@ var ui = `
 					decrement @data-hist
 				else if event.key is 'ArrowDown' and @data-hist < 0
 					increment @data-hist
-				end end
+				end
 				set #console-input.value to hdb.consoleHistory[hdb.consoleHistory.length + @data-hist as Int]
 					or oldContent
 				halt default


### PR DESCRIPTION
Fixes #539

The `#console-form` hyperscript had a duplicate `end` that caused the parser to exit the `on keydown` handler early. The next `set` command got parsed as a feature-level declaration, which requires element-scoped variables, so it threw "variables declared at the feature level must be element scoped".

One `end` removed, debugger works again.

Tested locally with both inline breakpoint (`on click breakpoint`) and function breakpoint (`def` with `breakpoint` inside). HDB opens, expression eval works, no console errors.