### PR TITLE
fix: anchor fetchThrowsOn regexes to avoid false positives on 2xx/3xx

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -4,7 +4,7 @@ export const config = {
     attributes: "_, script, data-script",
     defaultTransition: "all 500ms ease-in",
     disableSelector: "[disable-scripting], [data-disable-scripting]",
-    fetchThrowsOn: [/4.*/, /5.*/],
+    fetchThrowsOn: [/^4/, /^5/],
     hideShowStrategies: {},
     logAll: false,
     mutatingMethods: {

--- a/test/commands/fetch.js
+++ b/test/commands/fetch.js
@@ -196,6 +196,24 @@ test.describe("the fetch command", () => {
 		await expect(find('div')).toHaveText("the body");
 	});
 
+	test("does not throw on 204 No Content", async ({html, find, page}) => {
+		await page.route('**/test', async (route) => {
+			await route.fulfill({ status: 204, body: '' });
+		});
+		await html("<div _='on click fetch /test then put \"ok\" into me'></div>");
+		await find('div').dispatchEvent('click');
+		await expect(find('div')).toHaveText("ok");
+	});
+
+	test("does not throw on 304 Not Modified", async ({html, find, page}) => {
+		await page.route('**/test', async (route) => {
+			await route.fulfill({ status: 304, body: '' });
+		});
+		await html("<div _='on click fetch /test then put \"ok\" into me'></div>");
+		await find('div').dispatchEvent('click');
+		await expect(find('div')).toHaveText("ok");
+	});
+
 	test("as response does not throw on 404", async ({html, find, page}) => {
 		await page.route('**/test', async (route) => {
 			await route.fulfill({ status: 404, body: 'not found' });


### PR DESCRIPTION
## Problem

Default `fetchThrowsOn` patterns are unanchored:

```js
fetchThrowsOn: [/4.*/, /5.*/],
```

`/4.*/.test("204")` returns `true` because `"4"` appears at index 2. Same issue affects `304`, `250-259`, etc. Any 2xx/3xx response whose status string contains a `4` or `5` digit is incorrectly treated as an error and throws `fetch failed: <status> ...`.

Fixes #670.

## Repro

```html
<body _="on keypress fetch `/kbd/${event.key}` with method:'POST'">
```

Server returns `204 No Content`. Console:

```
fetch failed: 204 No Content (/kbd/d)
```

Docs say: "fetch throws on non-2xx responses (404, 500, etc.)" — current behavior contradicts that.

## Fix

Anchor the regexes:

```js
fetchThrowsOn: [/^4/, /^5/],
```

```
> /4.*/.test("204")   // true  (bug)
> /^4/.test("204")    // false (fixed)
> /^4/.test("404")    // true  (still throws as expected)
```

## Tests

Added two cases in `test/commands/fetch.js`:

- `does not throw on 204 No Content`
- `does not throw on 304 Not Modified`

All 25 fetch tests pass.