### PR TITLE
fix(debugger): keep editor line numbers 1:1 with source for breakpoints

### DIFF
--- a/src/ext/debugger.js
+++ b/src/ext/debugger.js
@@ -1113,27 +1113,25 @@ function createPanel(_hyperscript, ttd, timeline, domRestorer, recorder) {
 		stepStreamId = null;
 		root.classList.add('hs-paused');
 
-		// Show the paused element in the editor
+		// Show the paused element in the editor, then highlight the current line.
+		// selectElement mounts Monaco asynchronously, so the highlight must wait
+		// for editorReady — otherwise it lands on the stale/old editor and is lost
+		// (this is why the paused line often showed no highlight on first break).
+		// line == source line == display line now that normalizeScript preserves
+		// line numbers, so applyLineDecoration needs no offset.
+		var line = command.startToken && command.startToken.line;
 		if (pausedElement && pausedElement !== selectedElement) {
-			selectElement(pausedElement);
+			var editorReady = selectElement(pausedElement);
 			for (var i of $$('.d-el-item')) {
 				i.classList.toggle('selected', i._ref === pausedElement);
 			}
-		}
-
-		// Highlight current line in Monaco
-		if (monacoEditor && command.startToken) {
-			var line = command.startToken.line;
-			// For implicit returns, show line past the last real command
-			debugDecorations = monacoEditor.deltaDecorations(debugDecorations, [{
-				range: new window.monaco.Range(line, 1, line, 1),
-				options: {
-					isWholeLine: true,
-					className: 'hs-dbg-current-line',
-					glyphMarginClassName: 'hs-dbg-current-glyph',
-				}
-			}]);
-			monacoEditor.revealLineInCenter(line);
+			if (editorReady && typeof editorReady.then === 'function') {
+				editorReady.then(function() { applyLineDecoration(line); });
+			} else {
+				applyLineDecoration(line);
+			}
+		} else {
+			applyLineDecoration(line);
 		}
 
 		updateToolbarState();
@@ -1594,27 +1592,30 @@ function createPanel(_hyperscript, ttd, timeline, domRestorer, recorder) {
 		var lines = raw.split('\n');
 		if (lines.length <= 1) return raw.trim();
 
-		// Trim leading/trailing blank lines
-		while (lines.length && !lines[0].trim()) lines.shift();
-		while (lines.length && !lines[lines.length - 1].trim()) lines.pop();
-		if (!lines.length) return '';
+		// Line numbers must stay 1:1 with the source so Monaco lines match the
+		// tokenizer's token.line (used for breakpoints and the paused-line
+		// highlight). So we de-indent horizontally only and never add/remove
+		// lines: leading/trailing blank lines are kept as empty lines.
+		var first = 0;
+		while (first < lines.length && !lines[first].trim()) first++;
+		if (first === lines.length) return lines.map(function() { return ''; }).join('\n');
 
-		// Find the minimum indent of lines 2+ (continuation lines)
-		// These have HTML-level indentation we want to strip
+		// Find the minimum indent of the continuation lines (after the first
+		// real line). These carry HTML-level indentation we want to strip.
 		var minIndent = Infinity;
-		for (var i = 1; i < lines.length; i++) {
+		for (var i = first + 1; i < lines.length; i++) {
 			if (!lines[i].trim()) continue;
 			var indent = lines[i].match(/^(\s*)/)[1].length;
 			if (indent < minIndent) minIndent = indent;
 		}
 		if (minIndent === Infinity) minIndent = 0;
 
-		// First line: strip its own leading whitespace
-		var result = [lines[0].trim()];
-
-		// Remaining lines: strip the common indent, then add 2-space indent
-		for (var i = 1; i < lines.length; i++) {
-			if (!lines[i].trim()) { result.push(''); continue; }
+		var result = [];
+		for (var i = 0; i < lines.length; i++) {
+			if (i < first || !lines[i].trim()) { result.push(''); continue; }
+			// First real line: strip its own leading whitespace.
+			if (i === first) { result.push(lines[i].trim()); continue; }
+			// Continuation lines: strip the common indent, then add 2-space indent.
 			result.push('  ' + lines[i].substring(minIndent));
 		}
 


### PR DESCRIPTION
Part of #685 (item 6).

## The bug

`normalizeScript` reformats the script for display in the panel editor. It trimmed leading/trailing blank lines, which shifts every line up. But breakpoints and the paused-line highlight match against the tokenizer's original line numbers (`token.line`). So a script whose `_` attribute starts with a newline (extremely common in HTML) displayed `on click` on Monaco line 1 while the tokenizer has it on line 2. A gutter click stored the Monaco line; the breakpoint check compared the source line; they never matched.

That's the "breakpoints sometimes work" report: it worked only when there was no leading blank line. Setting breakpoints from code worked because that path uses source lines directly.

## The fix

Make the editor's line numbers stay 1:1 with the source so there is a single coordinate system everywhere (gutter clicks, the breakpoint check, and the paused-line highlight).

- **`normalizeScript`** now de-indents horizontally only and never adds or removes lines. Leading/trailing blank lines are kept as empty lines, so Monaco display line N == `token.line` N. This fixes the gutter mismatch and the paused-line highlight at the root, without scattering offset math across every call site.
- **`pauseAt`** now waits for `editorReady` before drawing the current-line decoration (mirroring `showLivePause`). `selectElement` mounts Monaco asynchronously, so the old synchronous highlight was applied to the not-yet-mounted editor and dropped, which is why the paused line frequently showed no highlight on the first break. It now reuses `applyLineDecoration`.

## Verification

- Algebraic check of `normalizeScript` on leading-newline, double-leading-newline, and no-leading-newline scripts: display line now equals source line in every case (previously off by the number of leading blank lines), and line count is preserved. No regression on the no-leading-newline case.
- End-to-end in the panel against a `_="\n  on click ... breakpoint ..."` script: execution pauses at the breakpoint, the Monaco model shows the command on the correct line, and the current line is highlighted (it was not highlighted at all before).

## Scope

Source-only change to `src/ext/debugger.js`. `dist/` is intentionally left out: the committed `dist/` is already stale relative to committed `src/` (e.g. the htmx-detection guard), so a rebuild here would pull in unrelated drift. Rebuild `dist/` separately at release.
