### PR TITLE
Replace defunct components example with working example on the home page

### DIFF
--- a/www/index.njk
+++ b/www/index.njk
@@ -165,13 +165,14 @@ title: ///_hyperscript
     <code>${}</code> interpolation, and the runtime handles re-rendering via morphing.</p>
     <p>Components should be easy.  Hyperscript makes them easy.</p>
 {% highlight "html" %}
-<template component="click-counter"
-          _="init set ^count to 0">
+<script type="text/hyperscript-template" component="click-counter" _="set ^count to 0">
+  
   <button _="on click increment ^count">+</button>
-  <span>Clicks: ${^count}</span>
-</template>
+  <span class="label">Clicks: ${^count}</span>
+</script>
 
 <click-counter></click-counter>
+<br>
 <click-counter></click-counter>
 {% endhighlight %}
 </div>


### PR DESCRIPTION
This replaces the defunct example for components on the home page with the similar working example for component state from the components page https://hyperscript.org/docs/components/#state .

#678 